### PR TITLE
Fixed typo in Makefile, target clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean-builders:
 	@for builder in $(BUILDER_TYPES) ; do \
 		if test -d $$builder ; then \
 			echo Deleting $$builder ; \
-			$(ROM) -rf $$builder ; \
+			$(RM) -rf $$builder ; \
 		fi ; \
 	done
 


### PR DESCRIPTION
The clean-builders target in the Makefile has a typo: $(ROM) instead of $(RM)
