### PR TITLE
Clean up and standardize postinstall[32|64].sh scripts

### DIFF
--- a/template/windows2008r2/script/postinstall64.sh
+++ b/template/windows2008r2/script/postinstall64.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922-x64.msi
-VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
-VMWARE_INSTALL=setup64.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0

--- a/template/windows2012/script/postinstall64.sh
+++ b/template/windows2012/script/postinstall64.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922-x64.msi
-VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
-VMWARE_INSTALL=setup64.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0

--- a/template/windows2012r2/script/postinstall64.sh
+++ b/template/windows2012r2/script/postinstall64.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922-x64.msi
-VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
-VMWARE_INSTALL=setup64.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0

--- a/template/windows7/script/postinstall32.sh
+++ b/template/windows7/script/postinstall32.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922.msi
-VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
-VMWARE_INSTALL=setup.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0

--- a/template/windows7/script/postinstall64.sh
+++ b/template/windows7/script/postinstall64.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922-x64.msi
-VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
-VMWARE_INSTALL=setup64.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0

--- a/template/windows8/script/postinstall32.sh
+++ b/template/windows8/script/postinstall32.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922.msi
-VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
-VMWARE_INSTALL=setup.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0

--- a/template/windows8/script/postinstall64.sh
+++ b/template/windows8/script/postinstall64.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922-x64.msi
-VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
-VMWARE_INSTALL=setup64.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0

--- a/template/windows81/script/postinstall32.sh
+++ b/template/windows81/script/postinstall32.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922.msi
-VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
-VMWARE_INSTALL=setup.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0

--- a/template/windows81/script/postinstall64.sh
+++ b/template/windows81/script/postinstall64.sh
@@ -1,48 +1,72 @@
-#set -x
+set -vx
 
-VAGRANT_HOME=/cygdrive/c/Users/vagrant
-# Install ssh certificates
-mkdir $VAGRANT_HOME/.ssh
-chmod 700 $VAGRANT_HOME/.ssh
-cd $VAGRANT_HOME/.ssh
-wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
-chown -R vagrant $VAGRANT_HOME/.ssh
-cd ..
+cd $HOME
 
-cd $VAGRANT_HOME
+# Configure ssh for the user with no passphrase
+ssh-user-config -y -p ""
 
-ZIP_INSTALL=7z922-x64.msi
-VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
-VMWARE_INSTALL=setup64.exe
+# Install vagrant public key
+if [ ! -f vagrant.pub ]; then
+  wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
+fi
+cat vagrant.pub >>$HOME/.ssh/authorized_keys
+rm -f vagrant.pub
+
+if wmic os get osarchitecture | grep -q 64-bit;then
+    ZIP_INSTALL=7z922-x64.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
+    VMWARE_INSTALL=setup64.exe
+else
+    ZIP_INSTALL=7z922.msi
+    VBOX_INSTALL=VBoxWindowsAdditions-x86.exe
+    VMWARE_INSTALL=setup.exe
+fi
 
 # 7zip will allow us to extract a file from an ISO
-wget http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+if [ ! -f $ZIP_INSTALL ]; then
+  wget --no-check-certificate http://downloads.sourceforge.net/sevenzip/$ZIP_INSTALL
+fi
 msiexec /qb /i $ZIP_INSTALL
+
+# Cleanup
+rm -f $ZIP_INSTALL
+
+SEVENZIP_HOME=$(reg query HKCU\\SOFTWARE\\7-Zip /v Path | sed -nre 's/^\s*Path\s*REG_SZ\s*(.*)$/\1/ p')
+
+# Add the path to 7zip to the system search path
+for pf in "$SEVENZIP_HOME" "$PROGRAMFILES/7-Zip" "$ProgramW6432/7-Zip" "$SYSTEMDRIVE/Program Files/7-Zip"  "$SYSTEMDRIVE/Program Files(x86)/7-Zip"; do
+  if [[ -d "$(cygpath "$pf")" ]]; then
+    PATH="$PATH:$(cygpath "$pf")"
+    break
+  fi
+done
 
 if [ -f VBoxGuestAdditions.iso ]; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x VBoxGuestAdditions.iso $VBOX_INSTALL
+    7z x VBoxGuestAdditions.iso $VBOX_INSTALL
 
     # Mark Oracle as a trusted installer
-    certutil -addstore -f "TrustedPublisher" $(cygpath -d /cygdrive/a/oracle-cert.cer)
+    certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 
     # Install the Virtualbox Additions
     ./$VBOX_INSTALL /S
 
     # Cleanup
     rm -f VBoxGuestAdditions.iso
-    rm -f $VBOX_INSTALL.exe
+    rm -f $VBOX_INSTALL
 elif [ -f windows.iso ]; then
+  # Skip installing VMWare Tools, if it's already installed
+  if ! net start | grep -iq "VMware Tools"; then
     # Extract the installer from the ISO
-    /cygdrive/c/Program\ Files/7-Zip/7z.exe x windows.iso $VMWARE_INSTALL
+    7z x windows.iso $VMWARE_INSTALL
 
     # Install VMware tools
-    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL" || true
+    ./$VMWARE_INSTALL /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
     # Cleanup
-    rm -f windows.iso
     rm -f $VMWARE_INSTALL
+  fi
+  rm -f windows.iso
 fi
 
-# Cleanup
-rm -f $ZIP_INSTALL
+exit 0


### PR DESCRIPTION
Changelog:
- All postinstall32.sh's and postinstall64.sh's are now the same
- Autosense if 32-bit Windows, or 64-bit OS
- Removed hardcoded references to drive C:
- Replaced $VAGRANT_HOME with simply $HOME
- Configure ssh using standard Cygwin `ssh-user-config` command
- Don't install VMWare Tools, if it's already installed (<del>required for Windows 8.1 32-bit</del>).
- Exit with error code of zero (required by Packer)
- Do not download files, if they are provided via the template. For example:

```
"provisioners": [
{
    "type": "file",
    "source": "vagrant.pub",
    "destination": "vagrant.pub"
},
{
    "type": "file",
    "source": "7z922.msi",
    "destination": "7z922.msi"
},
```

Tested and working for the following boxes:

```
win2008r2-datacenter
win2008r2-enterprise
win2008r2-standard
win2008r2-web
win2012-datacenter
win2012-standard
win2012r2-datacenter
win2012r2-standard
win7x64-enterprise
win7x64-pro
win7x86-enterprise
win7x86-pro
win81x64-enterprise
win81x64-pro
win81x86-enterprise
win81x86-pro
win8x64-enterprise
win8x86-enterprise
```
