### PR TITLE
Added windows 8.1 32-bit support, standardized .json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ output-*
 iso
 crash.log
 tmp
+windows.iso
 
 .DS_Store

--- a/template/windows2008r2/win2008r2-datacenter.json
+++ b/template/windows2008r2/win2008r2-datacenter.json
@@ -18,7 +18,8 @@
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows2008r2/win2008r2-enterprise.json
+++ b/template/windows2008r2/win2008r2-enterprise.json
@@ -18,7 +18,8 @@
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows2008r2/win2008r2-standard.json
+++ b/template/windows2008r2/win2008r2-standard.json
@@ -18,7 +18,8 @@
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows2008r2/win2008r2-web.json
+++ b/template/windows2008r2/win2008r2-web.json
@@ -18,7 +18,8 @@
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows2012/win2012-datacenter.json
+++ b/template/windows2012/win2012-datacenter.json
@@ -18,7 +18,8 @@
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows2012/win2012-standard.json
+++ b/template/windows2012/win2012-standard.json
@@ -18,7 +18,8 @@
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows2012r2/win2012r2-datacenter.json
+++ b/template/windows2012r2/win2012r2-datacenter.json
@@ -46,7 +46,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows2012r2/win2012r2-standard.json
+++ b/template/windows2012r2/win2012r2-standard.json
@@ -46,7 +46,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows7/win7x64-enterprise.json
+++ b/template/windows7/win7x64-enterprise.json
@@ -9,16 +9,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win7x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows7/win7x64-pro.json
+++ b/template/windows7/win7x64-pro.json
@@ -9,16 +9,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win7x64-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows7/win7x86-enterprise.json
+++ b/template/windows7/win7x86-enterprise.json
@@ -9,16 +9,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win7x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall32.sh"
     ]
   }],

--- a/template/windows7/win7x86-pro.json
+++ b/template/windows7/win7x86-pro.json
@@ -9,16 +9,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win7x86-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall32.sh"
     ]
   }],

--- a/template/windows8/win8x64-enterprise.json
+++ b/template/windows8/win8x64-enterprise.json
@@ -9,16 +9,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win8x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows8/win8x86-enterprise.json
+++ b/template/windows8/win8x86-enterprise.json
@@ -9,16 +9,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win8x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "scsi0.virtualDev": "lsisas1068"
       }
     },
     {
@@ -44,7 +45,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall32.sh"
     ]
   }],

--- a/template/windows81/floppy/win81x86-enterprise/Autounattend.xml
+++ b/template/windows81/floppy/win81x86-enterprise/Autounattend.xml
@@ -118,21 +118,33 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd /c reg ADD &quot;HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System&quot; /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f</CommandLine>
+                    <Description>Disable UAC</Description>
+                    <Order>1</Order>
+                    <RequiresUserInput>false</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>e:\setup /S /v &quot;/qn REBOOT=R ADDLOCAL=ALL&quot;</CommandLine>
+                    <Description>Install VMware tools</Description>
+                    <Order>2</Order>
+                    <RequiresUserInput>false</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
                     <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
                     <Description>Disable computer password change</Description>
-                    <Order>1</Order>
+                    <Order>3</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
                     <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
+                    <Order>4</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
                     <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
+                    <Order>5</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>

--- a/template/windows81/floppy/win81x86-pro/Autounattend.xml
+++ b/template/windows81/floppy/win81x86-pro/Autounattend.xml
@@ -118,21 +118,33 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd /c reg ADD &quot;HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System&quot; /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f</CommandLine>
+                    <Description>Disable UAC</Description>
+                    <Order>1</Order>
+                    <RequiresUserInput>false</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>e:\setup /S /v &quot;/qn REBOOT=R ADDLOCAL=ALL&quot;</CommandLine>
+                    <Description>Install VMware tools</Description>
+                    <Order>2</Order>
+                    <RequiresUserInput>false</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
                     <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
                     <Description>Disable computer password change</Description>
-                    <Order>1</Order>
+                    <Order>3</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
                     <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
+                    <Order>4</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
                     <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
+                    <Order>5</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>

--- a/template/windows81/win81x64-enterprise.json
+++ b/template/windows81/win81x64-enterprise.json
@@ -9,10 +9,10 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win81x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -46,7 +46,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows81/win81x64-pro.json
+++ b/template/windows81/win81x64-pro.json
@@ -9,10 +9,10 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win81x64-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -46,7 +46,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall64.sh"
     ]
   }],

--- a/template/windows81/win81x86-enterprise.json
+++ b/template/windows81/win81x86-enterprise.json
@@ -9,17 +9,22 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win81x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
         "cpuid.coresPerSocket": "1",
-        "scsi0.virtualDev": "lsisas1068"
+        "scsi0.virtualDev": "lsisas1068",
+		"guestOS": "windows8",
+		"ethernet0.virtualDev": "vmxnet3",
+		"ide1:1.deviceType": "cdrom-image",
+		"ide1:1.fileName": "../../../windows.iso",
+		"ide1:1.present": "TRUE"
       }
     },
     {
@@ -45,7 +50,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall32.sh"
     ]
   }],

--- a/template/windows81/win81x86-enterprise.json
+++ b/template/windows81/win81x86-enterprise.json
@@ -3,7 +3,7 @@
     {
       "vm_name": "win81x86-enterprise",
       "type": "vmware",
-      "guest_os_type": "windows8-64",
+      "guest_os_type": "windows8",
       "iso_url": "../../iso/en_windows_8_1_enterprise_x86_dvd_2791510.iso",
       "iso_checksum": "405091efe4d58947db45a106b37dd064",
       "iso_checksum_type": "md5",
@@ -20,7 +20,6 @@
         "numvcpus": "1",
         "cpuid.coresPerSocket": "1",
         "scsi0.virtualDev": "lsisas1068",
-		"guestOS": "windows8",
 		"ethernet0.virtualDev": "vmxnet3",
 		"ide1:1.deviceType": "cdrom-image",
 		"ide1:1.fileName": "../../../windows.iso",
@@ -30,7 +29,7 @@
     {
       "vm_name": "win81x86-enterprise",
       "type": "virtualbox",
-      "guest_os_type": "Windows8_64",
+      "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_1_enterprise_x86_dvd_2791510.iso",
       "iso_checksum": "405091efe4d58947db45a106b37dd064",
       "iso_checksum_type": "md5",

--- a/template/windows81/win81x86-pro.json
+++ b/template/windows81/win81x86-pro.json
@@ -9,17 +9,22 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
+      "ssh_wait_timeout": "10000s",
       "floppy_files": ["floppy/win81x86-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",
         "cpuid.coresPerSocket": "1",
-        "scsi0.virtualDev": "lsisas1068"
+        "scsi0.virtualDev": "lsisas1068",
+		"guestOS": "windows8",
+		"ethernet0.virtualDev": "vmxnet3",
+		"ide1:1.deviceType": "cdrom-image",
+		"ide1:1.fileName": "../../../windows.iso",
+		"ide1:1.present": "TRUE"
       }
     },
     {
@@ -45,7 +50,6 @@
   "provisioners": [{
     "type": "shell",
     "scripts": [
-      "script/change-home-dirs.sh",
       "script/postinstall32.sh"
     ]
   }],

--- a/template/windows81/win81x86-pro.json
+++ b/template/windows81/win81x86-pro.json
@@ -20,7 +20,6 @@
         "numvcpus": "1",
         "cpuid.coresPerSocket": "1",
         "scsi0.virtualDev": "lsisas1068",
-		"guestOS": "windows8",
 		"ethernet0.virtualDev": "vmxnet3",
 		"ide1:1.deviceType": "cdrom-image",
 		"ide1:1.fileName": "../../../windows.iso",


### PR DESCRIPTION
Changelog:

Added `"scsi0.virtualDev": "lsisas1068"`, where missing
Removed `script/change-home-dirs.sh`, as it duplicates code in `postinstall*.sh`
Moved `"ssh_wait_timeout": "10000s"` to standard location
Changed `ethernet0.virtualDev` to `vmxnet3` (as `e1000` is not supported by Windows 8.1 32-bit)
Mounted `windows.iso` as drive E:, so VMWare Tools can be installed via Autounattend.xml (so `vmxnet3` driver works in Windows 8.1 32-bit)
Added `"guestOS": "windows8"` for Windows 8.1 32-bit, as `windows8-64` was being selected by default

I tested these changes, and the boxes

win2008r2-datacenter
win2008r2-enterprise
win2008r2-standard
win2008r2-web
win2012-standard
win2012r2-standard
win7x64-enterprise
win7x64-pro
win7x86-enterprise
win7x86-pro
win81x64-enterprise
win81x64-pro
win8x64-enterprise
win8x86-enterprise
win81x86-enterprise
win81x86-pro

successfully install OpenSSH, and VMWare Tools.

The boxes

win2012-datacenter
win2012r2-datacenter

**_sometimes**_ fail to build, as the sshd service logs the following error when it's started:

`sshd pid service sshd failed signal 11 raised`
