### PR TITLE
Fix missing TEMP and TMP environment variables

### DIFF
--- a/template/windows2008r2/floppy/install-cygwin-sshd.bat
+++ b/template/windows2008r2/floppy/install-cygwin-sshd.bat
@@ -46,5 +46,3 @@ rd /s /q %SystemDrive%\$Recycle.bin
 
 echo ==^> Starting the ssh service
 net start sshd
-
-endlocal

--- a/template/windows2008r2/script/provisioner.bat
+++ b/template/windows2008r2/script/provisioner.bat
@@ -3,10 +3,10 @@
 setlocal EnableExtensions EnableDelayedExpansion
 
 if "%PROVISIONER%" == "chef" (
-  :: TEMP is not defined in this shell instance, so define it ourselves
-  set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+  :: If TEMP is not defined in this shell instance, define it ourselves
+  if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
   set REMOTE_SOURCE_MSI_URL=https://www.opscode.com/chef/install.msi
-  set LOCAL_DESTINATION_MSI_PATH=%LOCAL_TEMP%\chef-client-latest.msi
+  set LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi
   set FALLBACK_QUERY_STRING=?DownloadContext=PowerShell
 
   :: Always latest, for now
@@ -21,5 +21,3 @@ if "%PROVISIONER%" == "chef" (
 ) else (
   echo ==^> Building box without a provisioner."
 )
-
-endlocal

--- a/template/windows2008r2/script/vagrant.bat
+++ b/template/windows2008r2/script/vagrant.bat
@@ -2,13 +2,8 @@
 
 setlocal EnableExtensions EnableDelayedExpansion
 
-set VAGRANT_USER=vagrant
-set VAGRANT_HOME=%SystemDrive%\Users\%VAGRANT_USER%
 set VAGRANT_KEY_URL=https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 
 echo ==^> Installing vagrant public key
-mkdir "%VAGRANT_HOME%\.ssh"
-REM bash -c 'wget --no-check-certificate "%VAGRANT_KEY_URL%" -O "%VAGRANT_HOME%\.ssh\authorized_keys"'
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%VAGRANT_HOME%\.ssh\authorized_keys')"<NUL
-
-endlocal
+mkdir "%USERPROFILE%\.ssh"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%USERPROFILE%\.ssh\authorized_keys')"<NUL

--- a/template/windows2008r2/script/vmtools.bat
+++ b/template/windows2008r2/script/vmtools.bat
@@ -2,7 +2,7 @@
 
 setlocal EnableDelayedExpansion EnableExtensions
 
-if "%ProgramFiles%" equ "%SystemDrive%\Program Files (x86)" (
+if exist "%SystemDrive%\Program Files (x86)" (
   set SEVENZIP_INSTALL=7z922-x64.msi
   set VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
   set VMWARE_INSTALL=setup64.exe
@@ -12,43 +12,43 @@ if "%ProgramFiles%" equ "%SystemDrive%\Program Files (x86)" (
   set VMWARE_INSTALL=setup.exe
 )
 
-:: TEMP is not defined in this shell instance, so define it ourselves
-set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+:: If TEMP is not defined in this shell instance, define it ourselves
+if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 set SEVENZIP_URL=http://downloads.sourceforge.net/sevenzip/%SEVENZIP_INSTALL%
-set SEVENZIP_INSTALL_LOCAL_PATH=%LOCAL_TEMP%\%SEVENZIP_INSTALL%
+set SEVENZIP_INSTALL_LOCAL_PATH=%TEMP%\%SEVENZIP_INSTALL%
 
-echo ==^> Downloadling %SEVENZIP_URL% to %SEVENZIP_INSTALL_LOCAL_PATH%
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '%SEVENZIP_INSTALL_LOCAL_PATH%')" <NUL
+echo ==^> Downloadling %SEVENZIP_URL% to "%SEVENZIP_INSTALL_LOCAL_PATH%"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '"%SEVENZIP_INSTALL_LOCAL_PATH%"')" <NUL
 echo ==^> Download complete
-echo ==^> Installing 7zip from %SEVENZIP_INSTALL_LOCAL_PATH%
-msiexec /qb /i %SEVENZIP_INSTALL_LOCAL_PATH%
+echo ==^> Installing 7zip from "%SEVENZIP_INSTALL_LOCAL_PATH%"
+msiexec /qb /i "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
 if "%PACKER_BUILDER_TYPE%" equ "vmware" (
   echo ==^> Extracting the VMWare Tools installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%LOCAL_TEMP%\vmware
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%TEMP%\vmware
 
   echo ==^> Installing VMware tools
-  "%LOCAL_TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
+  "%TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
   echo ==^> Cleaning up VMware tools install
-  del /F /S /Q "%LOCAL_TEMP%\vmware"
+  del /F /S /Q "%TEMP%\vmware"
 )
 
 if "%PACKER_BUILDER_TYPE%" equ "virtualbox" (
   echo ==^> Extracting the VirtualBox Guest Additions installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%LOCAL_TEMP%\virtualbox
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%TEMP%\virtualbox
 
   echo ==^> Installing Oracle certificate to keep install silent
   certutil -addstore -f "TrustedPublisher" a:\oracle-cert.cer
 
   echo ==^> Installing VirtualBox Guest Additions
-  %LOCAL_TEMP%\virtualbox\%VBOX_INSTALL% /S
+  "%TEMP%\virtualbox\%VBOX_INSTALL%" /S
 
   echo ==^> Cleaning up VirtualBox Guest Additions install
-  del /F /S /Q "%LOCAL_TEMP%\virtualbox"
+  del /F /S /Q "%TEMP%\virtualbox"
 )
 
 echo ==^> Uninstalling 7zip
-msiexec /qb /x %SEVENZIP_INSTALL_LOCAL_PATH%
+msiexec /qb /x "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
-endlocal
+del "%SEVENZIP_INSTALL_LOCAL_PATH%"

--- a/template/windows2008r2/win2008r2-datacenter.json
+++ b/template/windows2008r2/win2008r2-datacenter.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows2008r2/win2008r2-enterprise.json
+++ b/template/windows2008r2/win2008r2-enterprise.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows2008r2/win2008r2-standard.json
+++ b/template/windows2008r2/win2008r2-standard.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows2008r2/win2008r2-web.json
+++ b/template/windows2008r2/win2008r2-web.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows2012/floppy/install-cygwin-sshd.bat
+++ b/template/windows2012/floppy/install-cygwin-sshd.bat
@@ -47,5 +47,3 @@ rd /s /q %SystemDrive%\$Recycle.bin
 
 echo ==^> Starting the ssh service
 net start sshd
-
-endlocal

--- a/template/windows2012/script/provisioner.bat
+++ b/template/windows2012/script/provisioner.bat
@@ -3,10 +3,10 @@
 setlocal EnableExtensions EnableDelayedExpansion
 
 if "%PROVISIONER%" == "chef" (
-  :: TEMP is not defined in this shell instance, so define it ourselves
-  set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+  :: If TEMP is not defined in this shell instance, define it ourselves
+  if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
   set REMOTE_SOURCE_MSI_URL=https://www.opscode.com/chef/install.msi
-  set LOCAL_DESTINATION_MSI_PATH=%LOCAL_TEMP%\chef-client-latest.msi
+  set LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi
   set FALLBACK_QUERY_STRING=?DownloadContext=PowerShell
 
   :: Always latest, for now
@@ -21,5 +21,3 @@ if "%PROVISIONER%" == "chef" (
 ) else (
   echo ==^> Building box without a provisioner."
 )
-
-endlocal

--- a/template/windows2012/script/vagrant.bat
+++ b/template/windows2012/script/vagrant.bat
@@ -2,13 +2,8 @@
 
 setlocal EnableExtensions EnableDelayedExpansion
 
-set VAGRANT_USER=vagrant
-set VAGRANT_HOME=%SystemDrive%\Users\%VAGRANT_USER%
 set VAGRANT_KEY_URL=https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 
 echo ==^> Installing vagrant public key
-mkdir "%VAGRANT_HOME%\.ssh"
-REM bash -c 'wget --no-check-certificate "%VAGRANT_KEY_URL%" -O "%VAGRANT_HOME%\.ssh\authorized_keys"'
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%VAGRANT_HOME%\.ssh\authorized_keys')"<NUL
-
-endlocal
+mkdir "%USERPROFILE%\.ssh"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%USERPROFILE%\.ssh\authorized_keys')"<NUL

--- a/template/windows2012/script/vmtools.bat
+++ b/template/windows2012/script/vmtools.bat
@@ -12,43 +12,43 @@ if exist "%SystemDrive%\Program Files (x86)" (
   set VMWARE_INSTALL=setup.exe
 )
 
-:: TEMP is not defined in this shell instance, so define it ourselves
-set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+:: If TEMP is not defined in this shell instance, define it ourselves
+if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 set SEVENZIP_URL=http://downloads.sourceforge.net/sevenzip/%SEVENZIP_INSTALL%
-set SEVENZIP_INSTALL_LOCAL_PATH=%LOCAL_TEMP%\%SEVENZIP_INSTALL%
+set SEVENZIP_INSTALL_LOCAL_PATH=%TEMP%\%SEVENZIP_INSTALL%
 
-echo ==^> Downloadling %SEVENZIP_URL% to %SEVENZIP_INSTALL_LOCAL_PATH%
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '%SEVENZIP_INSTALL_LOCAL_PATH%')" <NUL
+echo ==^> Downloadling %SEVENZIP_URL% to "%SEVENZIP_INSTALL_LOCAL_PATH%"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '"%SEVENZIP_INSTALL_LOCAL_PATH%"')" <NUL
 echo ==^> Download complete
-echo ==^> Installing 7zip from %SEVENZIP_INSTALL_LOCAL_PATH%
-msiexec /qb /i %SEVENZIP_INSTALL_LOCAL_PATH%
+echo ==^> Installing 7zip from "%SEVENZIP_INSTALL_LOCAL_PATH%"
+msiexec /qb /i "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
 if "%PACKER_BUILDER_TYPE%" equ "vmware" (
   echo ==^> Extracting the VMWare Tools installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%LOCAL_TEMP%\vmware
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%TEMP%\vmware
 
   echo ==^> Installing VMware tools
-  "%LOCAL_TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
+  "%TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
   echo ==^> Cleaning up VMware tools install
-  del /F /S /Q "%LOCAL_TEMP%\vmware"
+  del /F /S /Q "%TEMP%\vmware"
 )
 
 if "%PACKER_BUILDER_TYPE%" equ "virtualbox" (
   echo ==^> Extracting the VirtualBox Guest Additions installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%LOCAL_TEMP%\virtualbox
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%TEMP%\virtualbox
 
   echo ==^> Installing Oracle certificate to keep install silent
   certutil -addstore -f "TrustedPublisher" a:\oracle-cert.cer
 
   echo ==^> Installing VirtualBox Guest Additions
-  %LOCAL_TEMP%\virtualbox\%VBOX_INSTALL% /S
+  "%TEMP%\virtualbox\%VBOX_INSTALL%" /S
 
   echo ==^> Cleaning up VirtualBox Guest Additions install
-  del /F /S /Q "%LOCAL_TEMP%\virtualbox"
+  del /F /S /Q "%TEMP%\virtualbox"
 )
 
 echo ==^> Uninstalling 7zip
-msiexec /qb /x %SEVENZIP_INSTALL_LOCAL_PATH%
+msiexec /qb /x "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
-endlocal
+del "%SEVENZIP_INSTALL_LOCAL_PATH%"

--- a/template/windows2012/win2012-datacenter.json
+++ b/template/windows2012/win2012-datacenter.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows2012/win2012-standard.json
+++ b/template/windows2012/win2012-standard.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows2012r2/floppy/install-cygwin-sshd.bat
+++ b/template/windows2012r2/floppy/install-cygwin-sshd.bat
@@ -47,5 +47,3 @@ rd /s /q %SystemDrive%\$Recycle.bin
 
 echo ==^> Starting the ssh service
 net start sshd
-
-endlocal

--- a/template/windows2012r2/script/provisioner.bat
+++ b/template/windows2012r2/script/provisioner.bat
@@ -3,10 +3,10 @@
 setlocal EnableExtensions EnableDelayedExpansion
 
 if "%PROVISIONER%" == "chef" (
-  :: TEMP is not defined in this shell instance, so define it ourselves
-  set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+  :: If TEMP is not defined in this shell instance, define it ourselves
+  if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
   set REMOTE_SOURCE_MSI_URL=https://www.opscode.com/chef/install.msi
-  set LOCAL_DESTINATION_MSI_PATH=%LOCAL_TEMP%\chef-client-latest.msi
+  set LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi
   set FALLBACK_QUERY_STRING=?DownloadContext=PowerShell
 
   :: Always latest, for now
@@ -21,5 +21,3 @@ if "%PROVISIONER%" == "chef" (
 ) else (
   echo ==^> Building box without a provisioner."
 )
-
-endlocal

--- a/template/windows2012r2/script/vagrant.bat
+++ b/template/windows2012r2/script/vagrant.bat
@@ -2,13 +2,8 @@
 
 setlocal EnableExtensions EnableDelayedExpansion
 
-set VAGRANT_USER=vagrant
-set VAGRANT_HOME=%SystemDrive%\Users\%VAGRANT_USER%
 set VAGRANT_KEY_URL=https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 
 echo ==^> Installing vagrant public key
-mkdir "%VAGRANT_HOME%\.ssh"
-REM bash -c 'wget --no-check-certificate "%VAGRANT_KEY_URL%" -O "%VAGRANT_HOME%\.ssh\authorized_keys"'
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%VAGRANT_HOME%\.ssh\authorized_keys')"<NUL
-
-endlocal
+mkdir "%USERPROFILE%\.ssh"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%USERPROFILE%\.ssh\authorized_keys')"<NUL

--- a/template/windows2012r2/script/vmtools.bat
+++ b/template/windows2012r2/script/vmtools.bat
@@ -12,43 +12,43 @@ if exist "%SystemDrive%\Program Files (x86)" (
   set VMWARE_INSTALL=setup.exe
 )
 
-:: TEMP is not defined in this shell instance, so define it ourselves
-set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+:: If TEMP is not defined in this shell instance, define it ourselves
+if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 set SEVENZIP_URL=http://downloads.sourceforge.net/sevenzip/%SEVENZIP_INSTALL%
-set SEVENZIP_INSTALL_LOCAL_PATH=%LOCAL_TEMP%\%SEVENZIP_INSTALL%
+set SEVENZIP_INSTALL_LOCAL_PATH=%TEMP%\%SEVENZIP_INSTALL%
 
-echo ==^> Downloadling %SEVENZIP_URL% to %SEVENZIP_INSTALL_LOCAL_PATH%
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '%SEVENZIP_INSTALL_LOCAL_PATH%')" <NUL
+echo ==^> Downloadling %SEVENZIP_URL% to "%SEVENZIP_INSTALL_LOCAL_PATH%"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '"%SEVENZIP_INSTALL_LOCAL_PATH%"')" <NUL
 echo ==^> Download complete
-echo ==^> Installing 7zip from %SEVENZIP_INSTALL_LOCAL_PATH%
-msiexec /qb /i %SEVENZIP_INSTALL_LOCAL_PATH%
+echo ==^> Installing 7zip from "%SEVENZIP_INSTALL_LOCAL_PATH%"
+msiexec /qb /i "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
 if "%PACKER_BUILDER_TYPE%" equ "vmware" (
   echo ==^> Extracting the VMWare Tools installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%LOCAL_TEMP%\vmware
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%TEMP%\vmware
 
   echo ==^> Installing VMware tools
-  "%LOCAL_TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
+  "%TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
   echo ==^> Cleaning up VMware tools install
-  del /F /S /Q "%LOCAL_TEMP%\vmware"
+  del /F /S /Q "%TEMP%\vmware"
 )
 
 if "%PACKER_BUILDER_TYPE%" equ "virtualbox" (
   echo ==^> Extracting the VirtualBox Guest Additions installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%LOCAL_TEMP%\virtualbox
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%TEMP%\virtualbox
 
   echo ==^> Installing Oracle certificate to keep install silent
   certutil -addstore -f "TrustedPublisher" a:\oracle-cert.cer
 
   echo ==^> Installing VirtualBox Guest Additions
-  %LOCAL_TEMP%\virtualbox\%VBOX_INSTALL% /S
+  "%TEMP%\virtualbox\%VBOX_INSTALL%" /S
 
   echo ==^> Cleaning up VirtualBox Guest Additions install
-  del /F /S /Q "%LOCAL_TEMP%\virtualbox"
+  del /F /S /Q "%TEMP%\virtualbox"
 )
 
 echo ==^> Uninstalling 7zip
-msiexec /qb /x %SEVENZIP_INSTALL_LOCAL_PATH%
+msiexec /qb /x "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
-endlocal
+del "%SEVENZIP_INSTALL_LOCAL_PATH%"

--- a/template/windows2012r2/win2012r2-datacenter.json
+++ b/template/windows2012r2/win2012r2-datacenter.json
@@ -53,9 +53,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows2012r2/win2012r2-standard.json
+++ b/template/windows2012r2/win2012r2-standard.json
@@ -53,9 +53,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows7/floppy/install-cygwin-sshd.bat
+++ b/template/windows7/floppy/install-cygwin-sshd.bat
@@ -46,5 +46,3 @@ rd /s /q %SystemDrive%\$Recycle.bin
 
 echo ==^> Starting the ssh service
 net start sshd
-
-endlocal

--- a/template/windows7/script/provisioner.bat
+++ b/template/windows7/script/provisioner.bat
@@ -3,10 +3,10 @@
 setlocal EnableExtensions EnableDelayedExpansion
 
 if "%PROVISIONER%" == "chef" (
-  :: TEMP is not defined in this shell instance, so define it ourselves
-  set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+  :: If TEMP is not defined in this shell instance, define it ourselves
+  if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
   set REMOTE_SOURCE_MSI_URL=https://www.opscode.com/chef/install.msi
-  set LOCAL_DESTINATION_MSI_PATH=%LOCAL_TEMP%\chef-client-latest.msi
+  set LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi
   set FALLBACK_QUERY_STRING=?DownloadContext=PowerShell
 
   :: Always latest, for now
@@ -21,5 +21,3 @@ if "%PROVISIONER%" == "chef" (
 ) else (
   echo ==^> Building box without a provisioner."
 )
-
-endlocal

--- a/template/windows7/script/vagrant.bat
+++ b/template/windows7/script/vagrant.bat
@@ -2,13 +2,8 @@
 
 setlocal EnableExtensions EnableDelayedExpansion
 
-set VAGRANT_USER=vagrant
-set VAGRANT_HOME=%SystemDrive%\Users\%VAGRANT_USER%
 set VAGRANT_KEY_URL=https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 
 echo ==^> Installing vagrant public key
-mkdir "%VAGRANT_HOME%\.ssh"
-REM bash -c 'wget --no-check-certificate "%VAGRANT_KEY_URL%" -O "%VAGRANT_HOME%\.ssh\authorized_keys"'
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%VAGRANT_HOME%\.ssh\authorized_keys')"<NUL
-
-endlocal
+mkdir "%USERPROFILE%\.ssh"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%USERPROFILE%\.ssh\authorized_keys')"<NUL

--- a/template/windows7/script/vmtools.bat
+++ b/template/windows7/script/vmtools.bat
@@ -2,7 +2,7 @@
 
 setlocal EnableDelayedExpansion EnableExtensions
 
-if "%ProgramFiles%" equ "%SystemDrive%\Program Files (x86)" (
+if exist "%SystemDrive%\Program Files (x86)" (
   set SEVENZIP_INSTALL=7z922-x64.msi
   set VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
   set VMWARE_INSTALL=setup64.exe
@@ -12,43 +12,43 @@ if "%ProgramFiles%" equ "%SystemDrive%\Program Files (x86)" (
   set VMWARE_INSTALL=setup.exe
 )
 
-:: TEMP is not defined in this shell instance, so define it ourselves
-set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+:: If TEMP is not defined in this shell instance, define it ourselves
+if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 set SEVENZIP_URL=http://downloads.sourceforge.net/sevenzip/%SEVENZIP_INSTALL%
-set SEVENZIP_INSTALL_LOCAL_PATH=%LOCAL_TEMP%\%SEVENZIP_INSTALL%
+set SEVENZIP_INSTALL_LOCAL_PATH=%TEMP%\%SEVENZIP_INSTALL%
 
-echo ==^> Downloadling %SEVENZIP_URL% to %SEVENZIP_INSTALL_LOCAL_PATH%
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '%SEVENZIP_INSTALL_LOCAL_PATH%')" <NUL
+echo ==^> Downloadling %SEVENZIP_URL% to "%SEVENZIP_INSTALL_LOCAL_PATH%"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '"%SEVENZIP_INSTALL_LOCAL_PATH%"')" <NUL
 echo ==^> Download complete
-echo ==^> Installing 7zip from %SEVENZIP_INSTALL_LOCAL_PATH%
-msiexec /qb /i %SEVENZIP_INSTALL_LOCAL_PATH%
+echo ==^> Installing 7zip from "%SEVENZIP_INSTALL_LOCAL_PATH%"
+msiexec /qb /i "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
 if "%PACKER_BUILDER_TYPE%" equ "vmware" (
   echo ==^> Extracting the VMWare Tools installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%LOCAL_TEMP%\vmware
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%TEMP%\vmware
 
   echo ==^> Installing VMware tools
-  "%LOCAL_TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
+  "%TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
   echo ==^> Cleaning up VMware tools install
-  del /F /S /Q "%LOCAL_TEMP%\vmware"
+  del /F /S /Q "%TEMP%\vmware"
 )
 
 if "%PACKER_BUILDER_TYPE%" equ "virtualbox" (
   echo ==^> Extracting the VirtualBox Guest Additions installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%LOCAL_TEMP%\virtualbox
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%TEMP%\virtualbox
 
   echo ==^> Installing Oracle certificate to keep install silent
   certutil -addstore -f "TrustedPublisher" a:\oracle-cert.cer
 
   echo ==^> Installing VirtualBox Guest Additions
-  %LOCAL_TEMP%\virtualbox\%VBOX_INSTALL% /S
+  "%TEMP%\virtualbox\%VBOX_INSTALL%" /S
 
   echo ==^> Cleaning up VirtualBox Guest Additions install
-  del /F /S /Q "%LOCAL_TEMP%\virtualbox"
+  del /F /S /Q "%TEMP%\virtualbox"
 )
 
 echo ==^> Uninstalling 7zip
-msiexec /qb /x %SEVENZIP_INSTALL_LOCAL_PATH%
+msiexec /qb /x "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
-endlocal
+del "%SEVENZIP_INSTALL_LOCAL_PATH%"

--- a/template/windows7/win7x64-enterprise.json
+++ b/template/windows7/win7x64-enterprise.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows7/win7x64-pro.json
+++ b/template/windows7/win7x64-pro.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows7/win7x86-enterprise.json
+++ b/template/windows7/win7x86-enterprise.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows7/win7x86-pro.json
+++ b/template/windows7/win7x86-pro.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows8/floppy/install-cygwin-sshd.bat
+++ b/template/windows8/floppy/install-cygwin-sshd.bat
@@ -46,5 +46,3 @@ rd /s /q %SystemDrive%\$Recycle.bin
 
 echo ==^> Starting the ssh service
 net start sshd
-
-endlocal

--- a/template/windows8/script/provisioner.bat
+++ b/template/windows8/script/provisioner.bat
@@ -3,10 +3,10 @@
 setlocal EnableExtensions EnableDelayedExpansion
 
 if "%PROVISIONER%" == "chef" (
-  :: TEMP is not defined in this shell instance, so define it ourselves
-  set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+  :: If TEMP is not defined in this shell instance, define it ourselves
+  if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
   set REMOTE_SOURCE_MSI_URL=https://www.opscode.com/chef/install.msi
-  set LOCAL_DESTINATION_MSI_PATH=%LOCAL_TEMP%\chef-client-latest.msi
+  set LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi
   set FALLBACK_QUERY_STRING=?DownloadContext=PowerShell
 
   :: Always latest, for now
@@ -21,5 +21,3 @@ if "%PROVISIONER%" == "chef" (
 ) else (
   echo ==^> Building box without a provisioner."
 )
-
-endlocal

--- a/template/windows8/script/vagrant.bat
+++ b/template/windows8/script/vagrant.bat
@@ -2,13 +2,8 @@
 
 setlocal EnableExtensions EnableDelayedExpansion
 
-set VAGRANT_USER=vagrant
-set VAGRANT_HOME=%SystemDrive%\Users\%VAGRANT_USER%
 set VAGRANT_KEY_URL=https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 
 echo ==^> Installing vagrant public key
-mkdir "%VAGRANT_HOME%\.ssh"
-REM bash -c 'wget --no-check-certificate "%VAGRANT_KEY_URL%" -O "%VAGRANT_HOME%\.ssh\authorized_keys"'
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%VAGRANT_HOME%\.ssh\authorized_keys')"<NUL
-
-endlocal
+mkdir "%USERPROFILE%\.ssh"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%USERPROFILE%\.ssh\authorized_keys')"<NUL

--- a/template/windows8/script/vmtools.bat
+++ b/template/windows8/script/vmtools.bat
@@ -2,7 +2,7 @@
 
 setlocal EnableDelayedExpansion EnableExtensions
 
-if "%ProgramFiles%" equ "%SystemDrive%\Program Files (x86)" (
+if exist "%SystemDrive%\Program Files (x86)" (
   set SEVENZIP_INSTALL=7z922-x64.msi
   set VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
   set VMWARE_INSTALL=setup64.exe
@@ -12,43 +12,43 @@ if "%ProgramFiles%" equ "%SystemDrive%\Program Files (x86)" (
   set VMWARE_INSTALL=setup.exe
 )
 
-:: TEMP is not defined in this shell instance, so define it ourselves
-set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+:: If TEMP is not defined in this shell instance, define it ourselves
+if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 set SEVENZIP_URL=http://downloads.sourceforge.net/sevenzip/%SEVENZIP_INSTALL%
-set SEVENZIP_INSTALL_LOCAL_PATH=%LOCAL_TEMP%\%SEVENZIP_INSTALL%
+set SEVENZIP_INSTALL_LOCAL_PATH=%TEMP%\%SEVENZIP_INSTALL%
 
-echo ==^> Downloadling %SEVENZIP_URL% to %SEVENZIP_INSTALL_LOCAL_PATH%
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '%SEVENZIP_INSTALL_LOCAL_PATH%')" <NUL
+echo ==^> Downloadling %SEVENZIP_URL% to "%SEVENZIP_INSTALL_LOCAL_PATH%"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '"%SEVENZIP_INSTALL_LOCAL_PATH%"')" <NUL
 echo ==^> Download complete
-echo ==^> Installing 7zip from %SEVENZIP_INSTALL_LOCAL_PATH%
-msiexec /qb /i %SEVENZIP_INSTALL_LOCAL_PATH%
+echo ==^> Installing 7zip from "%SEVENZIP_INSTALL_LOCAL_PATH%"
+msiexec /qb /i "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
 if "%PACKER_BUILDER_TYPE%" equ "vmware" (
   echo ==^> Extracting the VMWare Tools installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%LOCAL_TEMP%\vmware
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%TEMP%\vmware
 
   echo ==^> Installing VMware tools
-  "%LOCAL_TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
+  "%TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
   echo ==^> Cleaning up VMware tools install
-  del /F /S /Q "%LOCAL_TEMP%\vmware"
+  del /F /S /Q "%TEMP%\vmware"
 )
 
 if "%PACKER_BUILDER_TYPE%" equ "virtualbox" (
   echo ==^> Extracting the VirtualBox Guest Additions installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%LOCAL_TEMP%\virtualbox
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%TEMP%\virtualbox
 
   echo ==^> Installing Oracle certificate to keep install silent
   certutil -addstore -f "TrustedPublisher" a:\oracle-cert.cer
 
   echo ==^> Installing VirtualBox Guest Additions
-  %LOCAL_TEMP%\virtualbox\%VBOX_INSTALL% /S
+  "%TEMP%\virtualbox\%VBOX_INSTALL%" /S
 
   echo ==^> Cleaning up VirtualBox Guest Additions install
-  del /F /S /Q "%LOCAL_TEMP%\virtualbox"
+  del /F /S /Q "%TEMP%\virtualbox"
 )
 
 echo ==^> Uninstalling 7zip
-msiexec /qb /x %SEVENZIP_INSTALL_LOCAL_PATH%
+msiexec /qb /x "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
-endlocal
+del "%SEVENZIP_INSTALL_LOCAL_PATH%"

--- a/template/windows8/win8x64-enterprise.json
+++ b/template/windows8/win8x64-enterprise.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows8/win8x64-pro.json
+++ b/template/windows8/win8x64-pro.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows8/win8x86-enterprise.json
+++ b/template/windows8/win8x86-enterprise.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows8/win8x86-pro.json
+++ b/template/windows8/win8x86-pro.json
@@ -51,9 +51,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows81/floppy/install-cygwin-sshd.bat
+++ b/template/windows81/floppy/install-cygwin-sshd.bat
@@ -46,5 +46,3 @@ rd /s /q %SystemDrive%\$Recycle.bin
 
 echo ==^> Starting the ssh service
 net start sshd
-
-endlocal

--- a/template/windows81/script/provisioner.bat
+++ b/template/windows81/script/provisioner.bat
@@ -3,10 +3,10 @@
 setlocal EnableExtensions EnableDelayedExpansion
 
 if "%PROVISIONER%" == "chef" (
-  :: TEMP is not defined in this shell instance, so define it ourselves
-  set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+  :: If TEMP is not defined in this shell instance, define it ourselves
+  if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
   set REMOTE_SOURCE_MSI_URL=https://www.opscode.com/chef/install.msi
-  set LOCAL_DESTINATION_MSI_PATH=%LOCAL_TEMP%\chef-client-latest.msi
+  set LOCAL_DESTINATION_MSI_PATH=%TEMP%\chef-client-latest.msi
   set FALLBACK_QUERY_STRING=?DownloadContext=PowerShell
 
   :: Always latest, for now
@@ -21,5 +21,3 @@ if "%PROVISIONER%" == "chef" (
 ) else (
   echo ==^> Building box without a provisioner."
 )
-
-endlocal

--- a/template/windows81/script/vagrant.bat
+++ b/template/windows81/script/vagrant.bat
@@ -2,13 +2,8 @@
 
 setlocal EnableExtensions EnableDelayedExpansion
 
-set VAGRANT_USER=vagrant
-set VAGRANT_HOME=%SystemDrive%\Users\%VAGRANT_USER%
 set VAGRANT_KEY_URL=https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 
 echo ==^> Installing vagrant public key
-mkdir "%VAGRANT_HOME%\.ssh"
-REM bash -c 'wget --no-check-certificate "%VAGRANT_KEY_URL%" -O "%VAGRANT_HOME%\.ssh\authorized_keys"'
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%VAGRANT_HOME%\.ssh\authorized_keys')"<NUL
-
-endlocal
+mkdir "%USERPROFILE%\.ssh"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_KEY_URL%', '%USERPROFILE%\.ssh\authorized_keys')"<NUL

--- a/template/windows81/script/vmtools.bat
+++ b/template/windows81/script/vmtools.bat
@@ -2,7 +2,7 @@
 
 setlocal EnableDelayedExpansion EnableExtensions
 
-if "%ProgramFiles%" equ "%SystemDrive%\Program Files (x86)" (
+if exist "%SystemDrive%\Program Files (x86)" (
   set SEVENZIP_INSTALL=7z922-x64.msi
   set VBOX_INSTALL=VBoxWindowsAdditions-amd64.exe
   set VMWARE_INSTALL=setup64.exe
@@ -12,43 +12,43 @@ if "%ProgramFiles%" equ "%SystemDrive%\Program Files (x86)" (
   set VMWARE_INSTALL=setup.exe
 )
 
-:: TEMP is not defined in this shell instance, so define it ourselves
-set LOCAL_TEMP=%USERPROFILE%\AppData\Local\Temp
+:: If TEMP is not defined in this shell instance, define it ourselves
+if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 set SEVENZIP_URL=http://downloads.sourceforge.net/sevenzip/%SEVENZIP_INSTALL%
-set SEVENZIP_INSTALL_LOCAL_PATH=%LOCAL_TEMP%\%SEVENZIP_INSTALL%
+set SEVENZIP_INSTALL_LOCAL_PATH=%TEMP%\%SEVENZIP_INSTALL%
 
-echo ==^> Downloadling %SEVENZIP_URL% to %SEVENZIP_INSTALL_LOCAL_PATH%
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '%SEVENZIP_INSTALL_LOCAL_PATH%')" <NUL
+echo ==^> Downloadling %SEVENZIP_URL% to "%SEVENZIP_INSTALL_LOCAL_PATH%"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '"%SEVENZIP_INSTALL_LOCAL_PATH%"')" <NUL
 echo ==^> Download complete
-echo ==^> Installing 7zip from %SEVENZIP_INSTALL_LOCAL_PATH%
-msiexec /qb /i %SEVENZIP_INSTALL_LOCAL_PATH%
+echo ==^> Installing 7zip from "%SEVENZIP_INSTALL_LOCAL_PATH%"
+msiexec /qb /i "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
 if "%PACKER_BUILDER_TYPE%" equ "vmware" (
   echo ==^> Extracting the VMWare Tools installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%LOCAL_TEMP%\vmware
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\windows.iso -o%TEMP%\vmware
 
   echo ==^> Installing VMware tools
-  "%LOCAL_TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
+  "%TEMP%\vmware\%VMWARE_INSTALL%" /S /v "/qn REBOOT=R ADDLOCAL=ALL"
 
   echo ==^> Cleaning up VMware tools install
-  del /F /S /Q "%LOCAL_TEMP%\vmware"
+  del /F /S /Q "%TEMP%\vmware"
 )
 
 if "%PACKER_BUILDER_TYPE%" equ "virtualbox" (
   echo ==^> Extracting the VirtualBox Guest Additions installer
-  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%LOCAL_TEMP%\virtualbox
+  "%SystemDrive%\Program Files\7-Zip\7z.exe" x %USERPROFILE%\VBoxGuestAdditions.iso -o%TEMP%\virtualbox
 
   echo ==^> Installing Oracle certificate to keep install silent
   certutil -addstore -f "TrustedPublisher" a:\oracle-cert.cer
 
   echo ==^> Installing VirtualBox Guest Additions
-  %LOCAL_TEMP%\virtualbox\%VBOX_INSTALL% /S
+  "%TEMP%\virtualbox\%VBOX_INSTALL%" /S
 
   echo ==^> Cleaning up VirtualBox Guest Additions install
-  del /F /S /Q "%LOCAL_TEMP%\virtualbox"
+  del /F /S /Q "%TEMP%\virtualbox"
 )
 
 echo ==^> Uninstalling 7zip
-msiexec /qb /x %SEVENZIP_INSTALL_LOCAL_PATH%
+msiexec /qb /x "%SEVENZIP_INSTALL_LOCAL_PATH%"
 
-endlocal
+del "%SEVENZIP_INSTALL_LOCAL_PATH%"

--- a/template/windows81/win81x64-enterprise.json
+++ b/template/windows81/win81x64-enterprise.json
@@ -53,9 +53,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows81/win81x64-pro.json
+++ b/template/windows81/win81x64-pro.json
@@ -53,9 +53,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows81/win81x86-enterprise.json
+++ b/template/windows81/win81x86-enterprise.json
@@ -52,9 +52,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",

--- a/template/windows81/win81x86-pro.json
+++ b/template/windows81/win81x86-pro.json
@@ -52,9 +52,12 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}",
+        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
+        "USERNAME=$USER"
       ],
-      "execute_command": "{{.Vars}} cmd /c C:/cygwin/tmp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [
         "script/vagrant.bat",
         "script/provisioner.bat",


### PR DESCRIPTION
Changelog: 
- All windows templates: Added `TEMP` and `TMP` variables as Cygwin doesn't pass them to `cmd`
- All windows scripts: Changed `%LOCAL_TEMP%` to `%TEMP%` now that it's properly initialized
- All windows templates: Fixed `USERNAME` variable as Cygwin sets this to `cyg_server`
- All windows templates: Changed `C:/cygwin/tmp/script.bat` to `$(/bin/cygpath -m '{{.Path}}')`
- All `vagrant.bat`s: Use `%USERPROFILE%` as it's always available
- All `vmtools.bat`s: Standardized (use `if exist "%SystemDrive%\Program Files (x86)"` throughout)
- All `vmtools.bat`s: Delete all downloads after use
- All `vmtools.bat`s: Quoted paths, as appropriate
- All `.bat` files: Removed `endlocal`s, as it's implied (see `SETLOCAL /?`)
