### PR TITLE
Moved Autounattend.xml's FirstLogonCommands from .xml files to .bat files

### DIFF
--- a/template/windows2008r2/floppy/00-run-all-scripts.cmd
+++ b/template/windows2008r2/floppy/00-run-all-scripts.cmd
@@ -1,0 +1,31 @@
+@echo off
+setlocal enableextensions disabledelayedexpansion
+
+CD /D %~dp0
+
+PATH=%~dp0;%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\WindowsPowerShell\v1.0;%PATH%
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: started. >>"%TEMP%\%~n0.log"
+title %0: started
+
+for /F %%I in ('dir /b /on *.bat *.cmd') do (
+  if /I not "%%~nxI" == "%~nx0" (
+    echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+    echo %0: executing %%~I >>"%TEMP%\%~n0.log"
+
+    title Executing %%~I...
+    if exist tee.exe (
+      cmd /c "%%~nxI" 2>&1 | tee "%TEMP%\%%~nI.log"
+    ) else (
+      cmd /c "%%~nxI"
+    )
+    set EL=%ERRORLEVEL%
+
+    echo %%~I returned error %EL% >>"%TEMP%\%~n0.log"
+  )
+)
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: finished. >>"%TEMP%\%~n0.log"
+title %0: finished

--- a/template/windows2008r2/floppy/win2008r2-datacenter/Autounattend.xml
+++ b/template/windows2008r2/floppy/win2008r2-datacenter/Autounattend.xml
@@ -82,22 +82,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows2008r2/floppy/win2008r2-enterprise/Autounattend.xml
+++ b/template/windows2008r2/floppy/win2008r2-enterprise/Autounattend.xml
@@ -82,22 +82,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows2008r2/floppy/win2008r2-standard/Autounattend.xml
+++ b/template/windows2008r2/floppy/win2008r2-standard/Autounattend.xml
@@ -82,22 +82,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows2008r2/floppy/win2008r2-web/Autounattend.xml
+++ b/template/windows2008r2/floppy/win2008r2-web/Autounattend.xml
@@ -82,22 +82,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows2008r2/win2008r2-datacenter.json
+++ b/template/windows2008r2/win2008r2-datacenter.json
@@ -14,7 +14,13 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "floppy_files": ["floppy/win2008r2-datacenter/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "floppy_files": [
+        "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -32,13 +38,20 @@
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "disk_size": 40960,
-      "floppy_files": ["floppy/win2008r2-datacenter/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
+      "floppy_files": [
+        "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"]

--- a/template/windows2008r2/win2008r2-enterprise.json
+++ b/template/windows2008r2/win2008r2-enterprise.json
@@ -14,7 +14,13 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "floppy_files": ["floppy/win2008r2-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "floppy_files": [
+        "floppy/win2008r2-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -32,13 +38,20 @@
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "disk_size": 40960,
-      "floppy_files": ["floppy/win2008r2-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
+      "floppy_files": [
+        "floppy/win2008r2-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"]
@@ -68,6 +81,6 @@
   "post-processors": [{
     "type": "vagrant",
     "keep_input_artifact": false,
-    "output": "../../{{.Provider}}/win2008r2-enterprise--{{user `provisioner`}}{{user `provisioner_version`}}.box"
+    "output": "../../{{.Provider}}/win2008r2-enterprise-{{user `provisioner`}}{{user `provisioner_version`}}.box"
   }]
 }

--- a/template/windows2008r2/win2008r2-standard.json
+++ b/template/windows2008r2/win2008r2-standard.json
@@ -14,7 +14,13 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "floppy_files": ["floppy/win2008r2-standard/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "floppy_files": [
+        "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -32,13 +38,20 @@
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "disk_size": 40960,
-      "floppy_files": ["floppy/win2008r2-standard/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
+      "floppy_files": [
+        "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"]
@@ -68,6 +81,6 @@
   "post-processors": [{
     "type": "vagrant",
     "keep_input_artifact": false,
-    "output": "../../{{.Provider}}/win2008r2-standard--{{user `provisioner`}}{{user `provisioner_version`}}.box"
+    "output": "../../{{.Provider}}/win2008r2-standard-{{user `provisioner`}}{{user `provisioner_version`}}.box"
   }]
 }

--- a/template/windows2008r2/win2008r2-web.json
+++ b/template/windows2008r2/win2008r2-web.json
@@ -14,7 +14,13 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "floppy_files": ["floppy/win2008r2-web/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "floppy_files": [
+        "floppy/win2008r2-web/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -32,13 +38,20 @@
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "disk_size": 40960,
-      "floppy_files": ["floppy/win2008r2-web/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
+      "floppy_files": [
+        "floppy/win2008r2-web/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"]

--- a/template/windows2012/floppy/00-run-all-scripts.cmd
+++ b/template/windows2012/floppy/00-run-all-scripts.cmd
@@ -1,0 +1,31 @@
+@echo off
+setlocal enableextensions disabledelayedexpansion
+
+CD /D %~dp0
+
+PATH=%~dp0;%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\WindowsPowerShell\v1.0;%PATH%
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: started. >>"%TEMP%\%~n0.log"
+title %0: started
+
+for /F %%I in ('dir /b /on *.bat *.cmd') do (
+  if /I not "%%~nxI" == "%~nx0" (
+    echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+    echo %0: executing %%~I >>"%TEMP%\%~n0.log"
+
+    title Executing %%~I...
+    if exist tee.exe (
+      cmd /c "%%~nxI" 2>&1 | tee "%TEMP%\%%~nI.log"
+    ) else (
+      cmd /c "%%~nxI"
+    )
+    set EL=%ERRORLEVEL%
+
+    echo %%~I returned error %EL% >>"%TEMP%\%~n0.log"
+  )
+)
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: finished. >>"%TEMP%\%~n0.log"
+title %0: finished

--- a/template/windows2012/floppy/win2012-datacenter/Autounattend.xml
+++ b/template/windows2012/floppy/win2012-datacenter/Autounattend.xml
@@ -86,22 +86,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows2012/floppy/win2012-standard/Autounattend.xml
+++ b/template/windows2012/floppy/win2012-standard/Autounattend.xml
@@ -86,22 +86,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows2012/win2012-datacenter.json
+++ b/template/windows2012/win2012-datacenter.json
@@ -14,7 +14,13 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "floppy_files": ["floppy/win2012-datacenter/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "floppy_files": [
+        "floppy/win2012-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -32,12 +38,19 @@
       "iso_url": "../../iso/en_windows_server_2012_x64_dvd_915478.iso",
       "iso_checksum": "da91135483e24689bfdaf05d40301506",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win2012-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win2012-datacenter/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows2012/win2012-standard.json
+++ b/template/windows2012/win2012-standard.json
@@ -14,7 +14,13 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "floppy_files": ["floppy/win2012-standard/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "floppy_files": [
+        "floppy/win2012-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -32,12 +38,19 @@
       "iso_url": "../../iso/en_windows_server_2012_x64_dvd_915478.iso",
       "iso_checksum": "da91135483e24689bfdaf05d40301506",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win2012-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win2012-standard/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows2012r2/floppy/00-run-all-scripts.cmd
+++ b/template/windows2012r2/floppy/00-run-all-scripts.cmd
@@ -1,0 +1,31 @@
+@echo off
+setlocal enableextensions disabledelayedexpansion
+
+CD /D %~dp0
+
+PATH=%~dp0;%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\WindowsPowerShell\v1.0;%PATH%
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: started. >>"%TEMP%\%~n0.log"
+title %0: started
+
+for /F %%I in ('dir /b /on *.bat *.cmd') do (
+  if /I not "%%~nxI" == "%~nx0" (
+    echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+    echo %0: executing %%~I >>"%TEMP%\%~n0.log"
+
+    title Executing %%~I...
+    if exist tee.exe (
+      cmd /c "%%~nxI" 2>&1 | tee "%TEMP%\%%~nI.log"
+    ) else (
+      cmd /c "%%~nxI"
+    )
+    set EL=%ERRORLEVEL%
+
+    echo %%~I returned error %EL% >>"%TEMP%\%~n0.log"
+  )
+)
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: finished. >>"%TEMP%\%~n0.log"
+title %0: finished

--- a/template/windows2012r2/floppy/win2012r2-datacenter/Autounattend.xml
+++ b/template/windows2012r2/floppy/win2012r2-datacenter/Autounattend.xml
@@ -86,22 +86,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and tmeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows2012r2/floppy/win2012r2-standard/Autounattend.xml
+++ b/template/windows2012r2/floppy/win2012r2-standard/Autounattend.xml
@@ -88,22 +88,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows2012r2/win2012r2-datacenter.json
+++ b/template/windows2012r2/win2012r2-datacenter.json
@@ -14,7 +14,13 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "floppy_files": ["floppy/win2012r2-datacenter/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "floppy_files": [
+        "floppy/win2012r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -33,12 +39,19 @@
       "iso_url": "../../iso/en_windows_server_2012_r2_x64_dvd_2707946.iso",
       "iso_checksum": "0e7c09aab20dec3cd7eab236dab90e78",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win2012r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win2012r2-datacenter/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows2012r2/win2012r2-standard.json
+++ b/template/windows2012r2/win2012r2-standard.json
@@ -14,7 +14,13 @@
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "floppy_files": ["floppy/win2012r2-standard/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "floppy_files": [
+        "floppy/win2012r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -33,12 +39,19 @@
       "iso_url": "../../iso/en_windows_server_2012_r2_x64_dvd_2707946.iso",
       "iso_checksum": "0e7c09aab20dec3cd7eab236dab90e78",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win2012r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win2012r2-standard/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows7/floppy/00-run-all-scripts.cmd
+++ b/template/windows7/floppy/00-run-all-scripts.cmd
@@ -1,0 +1,31 @@
+@echo off
+setlocal enableextensions disabledelayedexpansion
+
+CD /D %~dp0
+
+PATH=%~dp0;%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\WindowsPowerShell\v1.0;%PATH%
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: started. >>"%TEMP%\%~n0.log"
+title %0: started
+
+for /F %%I in ('dir /b /on *.bat *.cmd') do (
+  if /I not "%%~nxI" == "%~nx0" (
+    echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+    echo %0: executing %%~I >>"%TEMP%\%~n0.log"
+
+    title Executing %%~I...
+    if exist tee.exe (
+      cmd /c "%%~nxI" 2>&1 | tee "%TEMP%\%%~nI.log"
+    ) else (
+      cmd /c "%%~nxI"
+    )
+    set EL=%ERRORLEVEL%
+
+    echo %%~I returned error %EL% >>"%TEMP%\%~n0.log"
+  )
+)
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: finished. >>"%TEMP%\%~n0.log"
+title %0: finished

--- a/template/windows7/floppy/disable-network-location-prompt.bat
+++ b/template/windows7/floppy/disable-network-location-prompt.bat
@@ -1,0 +1,5 @@
+echo on
+
+PATH=%SystemRoot%\System32;%PATH%
+
+REG ADD "HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff"

--- a/template/windows7/floppy/win7x64-enterprise/Autounattend.xml
+++ b/template/windows7/floppy/win7x64-enterprise/Autounattend.xml
@@ -82,28 +82,10 @@
             </OOBE>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff&quot;</CommandLine>
-                    <Description>Disable Set Network Location</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <RequiresUserInput>true</RequiresUserInput>
-                    <Order>4</Order>
-                    <Description>Install Cygwin SSHD</Description>
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows7/floppy/win7x64-pro/Autounattend.xml
+++ b/template/windows7/floppy/win7x64-pro/Autounattend.xml
@@ -84,28 +84,10 @@
             </OOBE>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff&quot;</CommandLine>
-                    <Description>Disable Set Network Location Prompt</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>4</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows7/floppy/win7x86-enterprise/Autounattend.xml
+++ b/template/windows7/floppy/win7x86-enterprise/Autounattend.xml
@@ -83,28 +83,10 @@
             </OOBE>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff&quot;</CommandLine>
-                    <Description>Disable Set Network Location Prompt</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>4</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows7/floppy/win7x86-pro/Autounattend.xml
+++ b/template/windows7/floppy/win7x86-pro/Autounattend.xml
@@ -83,28 +83,10 @@
             </OOBE>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Control\Network\NewNetworkWindowOff&quot;</CommandLine>
-                    <Description>Disable Set Network Location Prompt</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>4</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows7/win7x64-enterprise.json
+++ b/template/windows7/win7x64-enterprise.json
@@ -13,10 +13,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win7x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-network-location-prompt.bat",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -32,13 +39,21 @@
       "iso_url": "../../iso/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651.iso",
       "iso_checksum": "6467c3875955df4514395f0afcaaa62a",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "disk_size": 40960,
-      "floppy_files": ["floppy/win7x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
+      "floppy_files": [
+        "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-network-location-prompt.bat",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"]

--- a/template/windows7/win7x64-pro.json
+++ b/template/windows7/win7x64-pro.json
@@ -13,10 +13,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win7x64-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win7x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-network-location-prompt.bat",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -32,13 +39,21 @@
       "iso_url": "../../iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
       "iso_checksum": "3c394e66c208cfd641b976de10fe90b5",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "disk_size": 40960,
-      "floppy_files": ["floppy/win7x64-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
+      "floppy_files": [
+        "floppy/win7x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-network-location-prompt.bat",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"]

--- a/template/windows7/win7x86-enterprise.json
+++ b/template/windows7/win7x86-enterprise.json
@@ -13,10 +13,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win7x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win7x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-network-location-prompt.bat",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+        ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -32,13 +39,21 @@
       "iso_url": "../../iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
       "iso_checksum": "d6044be7093fb2737db63d340a1b2a03",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "disk_size": 40960,
-      "floppy_files": ["floppy/win7x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
+      "floppy_files": [
+        "floppy/win7x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-network-location-prompt.bat",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"]

--- a/template/windows7/win7x86-pro.json
+++ b/template/windows7/win7x86-pro.json
@@ -13,10 +13,17 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win7x86-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win7x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-network-location-prompt.bat",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -32,13 +39,21 @@
       "iso_url": "../../iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
       "iso_checksum": "f55d3916622dd4125be6336876559690",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "disk_size": 40960,
-      "floppy_files": ["floppy/win7x86-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
+      "floppy_files": [
+        "floppy/win7x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-network-location-prompt.bat",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],
         ["modifyvm", "{{.Name}}", "--cpus", "1"]

--- a/template/windows8/floppy/00-run-all-scripts.cmd
+++ b/template/windows8/floppy/00-run-all-scripts.cmd
@@ -1,0 +1,31 @@
+@echo off
+setlocal enableextensions disabledelayedexpansion
+
+CD /D %~dp0
+
+PATH=%~dp0;%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\WindowsPowerShell\v1.0;%PATH%
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: started. >>"%TEMP%\%~n0.log"
+title %0: started
+
+for /F %%I in ('dir /b /on *.bat *.cmd') do (
+  if /I not "%%~nxI" == "%~nx0" (
+    echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+    echo %0: executing %%~I >>"%TEMP%\%~n0.log"
+
+    title Executing %%~I...
+    if exist tee.exe (
+      cmd /c "%%~nxI" 2>&1 | tee "%TEMP%\%%~nI.log"
+    ) else (
+      cmd /c "%%~nxI"
+    )
+    set EL=%ERRORLEVEL%
+
+    echo %%~I returned error %EL% >>"%TEMP%\%~n0.log"
+  )
+)
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: finished. >>"%TEMP%\%~n0.log"
+title %0: finished

--- a/template/windows8/floppy/win8x64-enterprise/Autounattend.xml
+++ b/template/windows8/floppy/win8x64-enterprise/Autounattend.xml
@@ -128,22 +128,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows8/floppy/win8x64-pro/Autounattend.xml
+++ b/template/windows8/floppy/win8x64-pro/Autounattend.xml
@@ -135,22 +135,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD “HKLM\System\CurrentControlSet\Services\Netlogon\Parameters” /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows8/floppy/win8x86-enterprise/Autounattend.xml
+++ b/template/windows8/floppy/win8x86-enterprise/Autounattend.xml
@@ -118,22 +118,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine> cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows8/floppy/win8x86-pro/Autounattend.xml
+++ b/template/windows8/floppy/win8x86-pro/Autounattend.xml
@@ -123,22 +123,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD “HKLM\System\CurrentControlSet\Services\Netlogon\Parameters” /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows8/win8x64-enterprise.json
+++ b/template/windows8/win8x64-enterprise.json
@@ -13,10 +13,16 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win8x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win8x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -32,12 +38,19 @@
       "iso_url": "../../iso/en_windows_8_enterprise_x64_dvd_917522.iso",
       "iso_checksum": "27aa354b8088527ffcd32007b51b25bf",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win8x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win8x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows8/win8x64-pro.json
+++ b/template/windows8/win8x64-pro.json
@@ -13,10 +13,16 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win8x64-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win8x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -32,12 +38,19 @@
       "iso_url": "../../iso/en_windows_8_x64_dvd_915440.iso",
       "iso_checksum": "0e8f2199fae18fe510c23426e68f675a",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win8x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win8x64-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows8/win8x86-enterprise.json
+++ b/template/windows8/win8x86-enterprise.json
@@ -13,10 +13,16 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win8x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win8x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -32,12 +38,19 @@
       "iso_url": "../../iso/en_windows_8_enterprise_x86_dvd_917587.iso",
       "iso_checksum": "ad055cae50cef987586c51cc6cc3c62e",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win8x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win8x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows8/win8x86-pro.json
+++ b/template/windows8/win8x86-pro.json
@@ -13,10 +13,16 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win8x86-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win8x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -32,12 +38,19 @@
       "iso_url": "../../iso/en_windows_8_x86_dvd_915417.iso",
       "iso_checksum": "4252407333706df89a0c654924dd3f06",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win8x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win8x86-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows81/floppy/00-run-all-scripts.cmd
+++ b/template/windows81/floppy/00-run-all-scripts.cmd
@@ -1,0 +1,31 @@
+@echo off
+setlocal enableextensions disabledelayedexpansion
+
+CD /D %~dp0
+
+PATH=%~dp0;%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\WindowsPowerShell\v1.0;%PATH%
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: started. >>"%TEMP%\%~n0.log"
+title %0: started
+
+for /F %%I in ('dir /b /on *.bat *.cmd') do (
+  if /I not "%%~nxI" == "%~nx0" (
+    echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+    echo %0: executing %%~I >>"%TEMP%\%~n0.log"
+
+    title Executing %%~I...
+    if exist tee.exe (
+      cmd /c "%%~nxI" 2>&1 | tee "%TEMP%\%%~nI.log"
+    ) else (
+      cmd /c "%%~nxI"
+    )
+    set EL=%ERRORLEVEL%
+
+    echo %%~I returned error %EL% >>"%TEMP%\%~n0.log"
+  )
+)
+
+echo|time|findstr "current" >>"%TEMP%\%~n0.log"
+echo %0: finished. >>"%TEMP%\%~n0.log"
+title %0: finished

--- a/template/windows81/floppy/win81x64-enterprise/Autounattend.xml
+++ b/template/windows81/floppy/win81x64-enterprise/Autounattend.xml
@@ -128,22 +128,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
                     <RequiresUserInput>false</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set_power_config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows81/floppy/win81x64-pro/Autounattend.xml
+++ b/template/windows81/floppy/win81x64-pro/Autounattend.xml
@@ -133,22 +133,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set_power_config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>3</Order>
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows81/floppy/win81x86-enterprise/Autounattend.xml
+++ b/template/windows81/floppy/win81x86-enterprise/Autounattend.xml
@@ -118,22 +118,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows81/floppy/win81x86-pro/Autounattend.xml
+++ b/template/windows81/floppy/win81x86-pro/Autounattend.xml
@@ -122,22 +122,10 @@
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>REG ADD &quot;HKLM\System\CurrentControlSet\Services\Netlogon\Parameters&quot; /v DisablePasswordChange /t REG_DWORD /d 2 /f</CommandLine>
-                    <Description>Disable computer password change</Description>
+                    <CommandLine>cmd.exe /c a:\00-run-all-scripts.cmd</CommandLine>
+                    <Description>Run all *.bat and *.cmd scripts on drive A:</Description>
                     <Order>1</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:set-power-config.bat</CommandLine>
-                    <Description>Turn off all power saving and timeouts</Description>
-                    <Order>2</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd /c a:install-cygwin-sshd.bat</CommandLine>
-                    <Description>Install Cygwin SSHD</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>

--- a/template/windows81/win81x64-enterprise.json
+++ b/template/windows81/win81x64-enterprise.json
@@ -13,10 +13,16 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win81x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -33,12 +39,19 @@
       "iso_url": "../../iso/en_windows_8_1_enterprise_x64_dvd_2971902.iso",
       "iso_checksum": "8e194185fcce4ea737f274ee9005ddf0",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win81x64-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows81/win81x64-pro.json
+++ b/template/windows81/win81x64-pro.json
@@ -13,10 +13,16 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win81x64-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win81x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -33,12 +39,19 @@
       "iso_url": "../../iso/en_windows_8_1_x64_dvd_2707217.iso",
       "iso_checksum": "f104b78019e86e74b149ae5e510f7be9",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win81x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win81x64-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows81/win81x86-enterprise.json
+++ b/template/windows81/win81x86-enterprise.json
@@ -13,10 +13,16 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win81x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win81x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -33,12 +39,19 @@
       "iso_url": "../../iso/en_windows_8_1_enterprise_x86_dvd_2972289.iso",
       "iso_checksum": "bf620a67b5dda1e18e9ce17d25711201",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win81x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win81x86-enterprise/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],

--- a/template/windows81/win81x86-pro.json
+++ b/template/windows81/win81x86-pro.json
@@ -13,10 +13,16 @@
       "iso_checksum_type": "md5",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "floppy_files": ["floppy/win81x86-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat"],
+      "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win81x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat"
+      ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
-      "ssh_wait_timeout": "10000s",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
       "disk_size": 40960,
       "vmx_data": {
@@ -33,12 +39,19 @@
       "iso_url": "../../iso/en_windows_8_1_x86_dvd_2707392.iso",
       "iso_checksum": "7dd36fea0d004acfedbdb3a5521ef5ff",
       "iso_checksum_type": "md5",
-      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "floppy_files": [
+        "floppy/win81x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/disable-password-change.bat",
+        "floppy/set-power-config.bat",
+        "floppy/install-cygwin-sshd.bat",
+        "floppy/oracle-cert.cer"
+      ],
+      "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "floppy_files": ["floppy/win81x86-pro/Autounattend.xml", "floppy/set-power-config.bat", "floppy/install-cygwin-sshd.bat", "floppy/oracle-cert.cer"],
       "disk_size": 40960,
       "vboxmanage": [
         ["modifyvm", "{{.Name}}", "--memory", "768"],


### PR DESCRIPTION
Changlog:
- All `Autounattend.xml`s: Replaced `SynchronousCommand`s with `00-run-all-scripts.cmd` which runs all `*.bat` and `*.cmd`s found on floppy.
- All windows templates: Moved keys for consistency across templates (`disk_size`, `guest_additions_path`, `tools_upload_flavor`, `ssh_wait_timeout`
- All windows templates: Changed `--` to `-` in post-processor `output` keys, where found

This provides us numerous benefits:
- Allows us to define the scripts to be run in the templates, instead of the .xml file
- Allows us to easily log the output of the batch files
- Allows us to easily add better error handling/reporting, if we want
- Allows us to have a single configuration script, that sets the parameters to be used by all following scripts, if we want
- Allows us to have a single `Autounattend.xml`, that multiple templates use, for example, we could add a new template to support WinRM, per https://github.com/joefitzgerald/packer-windows/blob/master/answer_files/2012/Autounattend.xml
