### PR TITLE
Points to correct path for scripts

### DIFF
--- a/template/osx/packer/template.json
+++ b/template/osx/packer/template.json
@@ -35,17 +35,17 @@
   "provisioners": [
     {
       "destination": "/private/tmp/kcpassword",
-      "source": "../scripts/support/kcpassword",
+      "source": "../script/support/kcpassword",
       "type": "file"
     },
     {
       "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
       "scripts": [
-        "../scripts/vagrant.sh",
-        "../scripts/vmware.sh",
-        "../scripts/xcode-cli-tools.sh",
-        "../scripts/chef-omnibus.sh",
-        "../scripts/puppet.sh"
+        "../script/vagrant.sh",
+        "../script/vmware.sh",
+        "../script/xcode-cli-tools.sh",
+        "../script/chef-omnibus.sh",
+        "../script/puppet.sh"
       ],
       "type": "shell"
     },


### PR DESCRIPTION
I'm not sure if this was intentional or not. But if you look at the path, there is no `template/osx/scripts`, only `template/osx/script`. Therefore the template.json located at `template/osx/packer/template.json` would have incorrect paths. Also though, I'm not sure if [L43]('https://github.com/412andrewmortimer/basebox-packer/compare/misheska:master...412andrewmortimer:osx-packer-template?expand=1#diff-4cfcc974b4b26beebccee6699359c4f7L43') needs to be plural or singular.
