### PR TITLE
Fixed Openssh installation issues

### DIFF
--- a/template/windows2008r2/floppy/install-openssh-sshd.bat
+++ b/template/windows2008r2/floppy/install-openssh-sshd.bat
@@ -23,9 +23,6 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
-echo ==^> Deleting "%OPENSSH_EXE%"
-del "%OPENSSH_EXE%"
-
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F
@@ -50,3 +47,6 @@ echo ==^> Configuring firewall
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow service=OpenSSHd enable=yes
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%ProgramFiles%\OpenSSH\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"

--- a/template/windows2008r2/floppy/install-openssh-sshd.bat
+++ b/template/windows2008r2/floppy/install-openssh-sshd.bat
@@ -8,19 +8,23 @@ setlocal EnableDelayedExpansion EnableExtensions
 if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 
 if exist "%SystemDrive%\Program Files (x86)" (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1(x64).exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1(x64).exe"
 ) else (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1.exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1.exe"
 )
 
-set OPENSSH_URL=http://www.mls-software.com/files/!OPENSSH_INSTALL!
+set OPENSSH_URL=http://www.mls-software.com/files/%OPENSSH_INSTALL%
+set OPENSSH_EXE=%TEMP%\openssh.exe
 
 :: setup openssh
-echo ==^> Downloadng !OPENSSH_URL! to %TEMP%\openssh.exe
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('!OPENSSH_URL!', '%TEMP%\openssh.exe')"
+echo ==^> Downloadng %OPENSSH_URL% to %OPENSSH_EXE%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%OPENSSH_URL%', '%OPENSSH_EXE%')"
 echo ==^> Download complete
-echo ==^> Installing "%TEMP%\openssh.exe"
-cmd /c "%TEMP%\openssh.exe" /S /port=22 /privsep=1 /password=D@rj33l1ng
+echo ==^> Installing "%OPENSSH_EXE%"
+cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"
 
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
@@ -36,8 +40,8 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Fo
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
-cmd /c %windir%\System32\icacls.exe "%TEMP" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content C:\Users\vagrant\.ssh\environment "TEMP=C:\Windows\Temp""
+cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows2012/floppy/install-openssh-sshd.bat
+++ b/template/windows2012/floppy/install-openssh-sshd.bat
@@ -23,9 +23,6 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
-echo ==^> Deleting "%OPENSSH_EXE%"
-del "%OPENSSH_EXE%"
-
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F
@@ -50,3 +47,6 @@ echo ==^> Configuring firewall
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow service=OpenSSHd enable=yes
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%ProgramFiles%\OpenSSH\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"

--- a/template/windows2012/floppy/install-openssh-sshd.bat
+++ b/template/windows2012/floppy/install-openssh-sshd.bat
@@ -8,19 +8,23 @@ setlocal EnableDelayedExpansion EnableExtensions
 if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 
 if exist "%SystemDrive%\Program Files (x86)" (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1(x64).exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1(x64).exe"
 ) else (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1.exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1.exe"
 )
 
-set OPENSSH_URL=http://www.mls-software.com/files/!OPENSSH_INSTALL!
+set OPENSSH_URL=http://www.mls-software.com/files/%OPENSSH_INSTALL%
+set OPENSSH_EXE=%TEMP%\openssh.exe
 
 :: setup openssh
-echo ==^> Downloadng !OPENSSH_URL! to %TEMP%\openssh.exe
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('!OPENSSH_URL!', '%TEMP%\openssh.exe')"
+echo ==^> Downloadng %OPENSSH_URL% to %OPENSSH_EXE%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%OPENSSH_URL%', '%OPENSSH_EXE%')"
 echo ==^> Download complete
-echo ==^> Installing "%TEMP%\openssh.exe"
-cmd /c "%TEMP%\openssh.exe" /S /port=22 /privsep=1 /password=D@rj33l1ng
+echo ==^> Installing "%OPENSSH_EXE%"
+cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"
 
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
@@ -36,8 +40,8 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Fo
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
-cmd /c %windir%\System32\icacls.exe "%TEMP" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content C:\Users\vagrant\.ssh\environment "TEMP=C:\Windows\Temp""
+cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows2012r2/floppy/install-openssh-sshd.bat
+++ b/template/windows2012r2/floppy/install-openssh-sshd.bat
@@ -23,9 +23,6 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
-echo ==^> Deleting "%OPENSSH_EXE%"
-del "%OPENSSH_EXE%"
-
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F
@@ -50,3 +47,6 @@ echo ==^> Configuring firewall
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow service=OpenSSHd enable=yes
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%ProgramFiles%\OpenSSH\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"

--- a/template/windows2012r2/floppy/install-openssh-sshd.bat
+++ b/template/windows2012r2/floppy/install-openssh-sshd.bat
@@ -8,19 +8,23 @@ setlocal EnableDelayedExpansion EnableExtensions
 if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 
 if exist "%SystemDrive%\Program Files (x86)" (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1(x64).exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1(x64).exe"
 ) else (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1.exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1.exe"
 )
 
-set OPENSSH_URL=http://www.mls-software.com/files/!OPENSSH_INSTALL!
+set OPENSSH_URL=http://www.mls-software.com/files/%OPENSSH_INSTALL%
+set OPENSSH_EXE=%TEMP%\openssh.exe
 
 :: setup openssh
-echo ==^> Downloadng !OPENSSH_URL! to %TEMP%\openssh.exe
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('!OPENSSH_URL!', '%TEMP%\openssh.exe')"
+echo ==^> Downloadng %OPENSSH_URL% to %OPENSSH_EXE%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%OPENSSH_URL%', '%OPENSSH_EXE%')"
 echo ==^> Download complete
-echo ==^> Installing "%TEMP%\openssh.exe"
-cmd /c "%TEMP%\openssh.exe" /S /port=22 /privsep=1 /password=D@rj33l1ng
+echo ==^> Installing "%OPENSSH_EXE%"
+cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"
 
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
@@ -36,8 +40,8 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Fo
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
-cmd /c %windir%\System32\icacls.exe "%TEMP" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content C:\Users\vagrant\.ssh\environment "TEMP=C:\Windows\Temp""
+cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows7/floppy/install-openssh-sshd.bat
+++ b/template/windows7/floppy/install-openssh-sshd.bat
@@ -23,9 +23,6 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
-echo ==^> Deleting "%OPENSSH_EXE%"
-del "%OPENSSH_EXE%"
-
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F
@@ -50,3 +47,6 @@ echo ==^> Configuring firewall
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow service=OpenSSHd enable=yes
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%ProgramFiles%\OpenSSH\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"

--- a/template/windows7/floppy/install-openssh-sshd.bat
+++ b/template/windows7/floppy/install-openssh-sshd.bat
@@ -8,19 +8,23 @@ setlocal EnableDelayedExpansion EnableExtensions
 if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 
 if exist "%SystemDrive%\Program Files (x86)" (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1(x64).exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1(x64).exe"
 ) else (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1.exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1.exe"
 )
 
-set OPENSSH_URL=http://www.mls-software.com/files/!OPENSSH_INSTALL!
+set OPENSSH_URL=http://www.mls-software.com/files/%OPENSSH_INSTALL%
+set OPENSSH_EXE=%TEMP%\openssh.exe
 
 :: setup openssh
-echo ==^> Downloadng !OPENSSH_URL! to %TEMP%\openssh.exe
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('!OPENSSH_URL!', '%TEMP%\openssh.exe')"
+echo ==^> Downloadng %OPENSSH_URL% to %OPENSSH_EXE%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%OPENSSH_URL%', '%OPENSSH_EXE%')"
 echo ==^> Download complete
-echo ==^> Installing "%TEMP%\openssh.exe"
-cmd /c "%TEMP%\openssh.exe" /S /port=22 /privsep=1 /password=D@rj33l1ng
+echo ==^> Installing "%OPENSSH_EXE%"
+cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"
 
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
@@ -36,8 +40,8 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Fo
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
-cmd /c %windir%\System32\icacls.exe "%TEMP" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content C:\Users\vagrant\.ssh\environment "TEMP=C:\Windows\Temp""
+cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows8/floppy/install-openssh-sshd.bat
+++ b/template/windows8/floppy/install-openssh-sshd.bat
@@ -23,9 +23,6 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
-echo ==^> Deleting "%OPENSSH_EXE%"
-del "%OPENSSH_EXE%"
-
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F
@@ -50,3 +47,6 @@ echo ==^> Configuring firewall
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow service=OpenSSHd enable=yes
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%ProgramFiles%\OpenSSH\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"

--- a/template/windows8/floppy/install-openssh-sshd.bat
+++ b/template/windows8/floppy/install-openssh-sshd.bat
@@ -8,19 +8,23 @@ setlocal EnableDelayedExpansion EnableExtensions
 if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 
 if exist "%SystemDrive%\Program Files (x86)" (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1(x64).exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1(x64).exe"
 ) else (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1.exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1.exe"
 )
 
-set OPENSSH_URL=http://www.mls-software.com/files/!OPENSSH_INSTALL!
+set OPENSSH_URL=http://www.mls-software.com/files/%OPENSSH_INSTALL%
+set OPENSSH_EXE=%TEMP%\openssh.exe
 
 :: setup openssh
-echo ==^> Downloadng !OPENSSH_URL! to %TEMP%\openssh.exe
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('!OPENSSH_URL!', '%TEMP%\openssh.exe')"
+echo ==^> Downloadng %OPENSSH_URL% to %OPENSSH_EXE%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%OPENSSH_URL%', '%OPENSSH_EXE%')"
 echo ==^> Download complete
-echo ==^> Installing "%TEMP%\openssh.exe"
-cmd /c "%TEMP%\openssh.exe" /S /port=22 /privsep=1 /password=D@rj33l1ng
+echo ==^> Installing "%OPENSSH_EXE%"
+cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"
 
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
@@ -36,8 +40,8 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Fo
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
-cmd /c %windir%\System32\icacls.exe "%TEMP" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content C:\Users\vagrant\.ssh\environment "TEMP=C:\Windows\Temp""
+cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows81/floppy/install-openssh-sshd.bat
+++ b/template/windows81/floppy/install-openssh-sshd.bat
@@ -23,9 +23,6 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
-echo ==^> Deleting "%OPENSSH_EXE%"
-del "%OPENSSH_EXE%"
-
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F
@@ -50,3 +47,6 @@ echo ==^> Configuring firewall
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow service=OpenSSHd enable=yes
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%ProgramFiles%\OpenSSH\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"

--- a/template/windows81/floppy/install-openssh-sshd.bat
+++ b/template/windows81/floppy/install-openssh-sshd.bat
@@ -8,19 +8,23 @@ setlocal EnableDelayedExpansion EnableExtensions
 if not defined TEMP set TEMP=%USERPROFILE%\AppData\Local\Temp
 
 if exist "%SystemDrive%\Program Files (x86)" (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1(x64).exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1(x64).exe"
 ) else (
-  set OPENSSH_INSTALL="setupssh-6.3p1-1.exe"
+  set OPENSSH_INSTALL="setupssh-6.4p1-1.exe"
 )
 
-set OPENSSH_URL=http://www.mls-software.com/files/!OPENSSH_INSTALL!
+set OPENSSH_URL=http://www.mls-software.com/files/%OPENSSH_INSTALL%
+set OPENSSH_EXE=%TEMP%\openssh.exe
 
 :: setup openssh
-echo ==^> Downloadng !OPENSSH_URL! to %TEMP%\openssh.exe
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('!OPENSSH_URL!', '%TEMP%\openssh.exe')"
+echo ==^> Downloadng %OPENSSH_URL% to %OPENSSH_EXE%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%OPENSSH_URL%', '%OPENSSH_EXE%')"
 echo ==^> Download complete
-echo ==^> Installing "%TEMP%\openssh.exe"
-cmd /c "%TEMP%\openssh.exe" /S /port=22 /privsep=1 /password=D@rj33l1ng
+echo ==^> Installing "%OPENSSH_EXE%"
+cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
+
+echo ==^> Deleting "%OPENSSH_EXE%"
+del "%OPENSSH_EXE%"
 
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
@@ -36,8 +40,8 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Fo
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
-cmd /c %windir%\System32\icacls.exe "%TEMP" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content C:\Users\vagrant\.ssh\environment "TEMP=C:\Windows\Temp""
+cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH


### PR DESCRIPTION
Fixed "The filename, directory name, or volume label syntax is incorrect." (http://pastie.org/8588258 line 87 ) (floppy/install-openssh-sshd.bat)
Upgraded to Openssh 6.4 (floppy/install-openssh-sshd.bat)
Removed download after installation (floppy/install-openssh-sshd.bat)
Changed '!'s back to '%', as they were unneccessary (floppy/install-openssh-sshd.bat)
Changed C:\Users\vagrant to %USERPROFILE% (floppy/install-openssh-sshd.bat)
