### PR TITLE
Compiles correctly from ISO for VirtualBox now.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ virtualbox/%.box: %.json
 	cd $(dir $<); \
 	rm -rf output-virtualbox; \
 	mkdir -p ../../virtualbox; \
-	packer build -only=virtualbox $(notdir $<)
+	packer build -only=virtualbox-iso $(notdir $<)
 
 .PHONY: list
 list:

--- a/template/archlinux/arch201310-i686.json
+++ b/template/archlinux/arch201310-i686.json
@@ -30,7 +30,7 @@
   },
   {
     "vm_name": "arch201310-i686",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "iso_url": "http://mirrors.kernel.org/archlinux/iso/2013.10.01/archlinux-2013.10.01-dual.iso",
     "iso_checksum": "c0de9cde5f3c8f765a8fad06a07c5f6db3a93b15",
     "iso_checksum_type": "sha1",

--- a/template/archlinux/arch201310.json
+++ b/template/archlinux/arch201310.json
@@ -29,7 +29,7 @@
   },
   {
     "vm_name": "arch201310",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "iso_url": "http://mirrors.kernel.org/archlinux/iso/2013.10.01/archlinux-2013.10.01-dual.iso",
     "iso_checksum": "c0de9cde5f3c8f765a8fad06a07c5f6db3a93b15",
     "iso_checksum_type": "sha1",

--- a/template/centos/centos510-i386.json
+++ b/template/centos/centos510-i386.json
@@ -28,7 +28,7 @@
   },
   {
     "vm_name": "centos510-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/centos/5.10/isos/i386/CentOS-5.10-i386-bin-DVD-1of2.iso",
     "iso_checksum": "ec0acc2a4f6a813ea85bf1e36acb03f0",

--- a/template/centos/centos510.json
+++ b/template/centos/centos510.json
@@ -28,7 +28,7 @@
   },
   {
     "vm_name": "centos510",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirror.stanford.edu/yum/pub/centos/5.10/isos/x86_64/CentOS-5.10-x86_64-bin-DVD-1of2.iso",
     "iso_checksum": "715f7355074c00530cd6ee1d9f43cc3f",

--- a/template/centos/centos59-i386.json
+++ b/template/centos/centos59-i386.json
@@ -28,7 +28,7 @@
   },
   {
     "vm_name": "centos59-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirror.symnds.com/distributions/CentOS-vault/5.9/isos/i386/CentOS-5.9-i386-bin-DVD-1of2.iso",
     "iso_checksum": "78f976b190ce44716eb672f71203df978474dfb4",

--- a/template/centos/centos59.json
+++ b/template/centos/centos59.json
@@ -28,7 +28,7 @@
   },
   {
     "vm_name": "centos59",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirror.symnds.com/distributions/CentOS-vault/5.9/isos/x86_64/CentOS-5.9-x86_64-bin-DVD-1of2.iso",
     "iso_checksum": "bb795391846e76a7071893cbdf6163c3",

--- a/template/centos/centos64-i386.json
+++ b/template/centos/centos64-i386.json
@@ -28,7 +28,7 @@
   },
   {
     "vm_name": "centos64-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/centos/6.4/isos/i386/CentOS-6.4-i386-bin-DVD1.iso",
     "iso_checksum": "4bd3a1de6f6dfcd7a2199487abf5a9304d696cae",

--- a/template/centos/centos64.json
+++ b/template/centos/centos64.json
@@ -28,7 +28,7 @@
   },
   {
     "vm_name": "centos64",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/centos/6.4/isos/x86_64/CentOS-6.4-x86_64-bin-DVD1.iso",
     "iso_checksum": "0128cfc7c86072b13ee80dd013e0e5d7",

--- a/template/centos/centos65-i386.json
+++ b/template/centos/centos65-i386.json
@@ -28,7 +28,7 @@
   },
   {
     "vm_name": "centos65-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/centos/6.5/isos/i386/CentOS-6.5-i386-bin-DVD1.iso",
     "iso_checksum": "67ea68068ae53d1f23431072ec0288b3e1abfe4d",

--- a/template/centos/centos65.json
+++ b/template/centos/centos65.json
@@ -28,7 +28,7 @@
   },
   {
     "vm_name": "centos65",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/centos/6.5/isos/x86_64/CentOS-6.5-x86_64-bin-DVD1.iso",
     "iso_checksum": "32c7695b97f7dcd1f59a77a71f64f2957dddf738",

--- a/template/debian/debian607-i386.json
+++ b/template/debian/debian607-i386.json
@@ -42,7 +42,7 @@
   },
   {
     "vm_name": "debian607-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://cdimage.debian.org/cdimage/archive/6.0.7/i386/iso-cd/debian-6.0.7-i386-CD-1.iso",
     "iso_checksum": "de0d9ce1eb8d238dd3747a28586655b526b398a2",

--- a/template/debian/debian607.json
+++ b/template/debian/debian607.json
@@ -42,7 +42,7 @@
   },
   {
     "vm_name": "debian607",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://cdimage.debian.org/cdimage/archive/6.0.7/amd64/iso-cd/debian-6.0.7-amd64-CD-1.iso",
     "iso_checksum": "33877b8bff3a7def4ba1b551615d8459a3a7b268",

--- a/template/debian/debian608-i386.json
+++ b/template/debian/debian608-i386.json
@@ -42,7 +42,7 @@
   },
   {
     "vm_name": "debian608-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://cdimage.debian.org/cdimage/archive/6.0.8/i386/iso-cd/debian-6.0.8-i386-CD-1.iso",
     "iso_checksum": "144194cea77f0e527fd07bd6aa28d1ab50cb5a95",

--- a/template/debian/debian608.json
+++ b/template/debian/debian608.json
@@ -42,7 +42,7 @@
   },
   {
     "vm_name": "debian608",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://cdimage.debian.org/cdimage/archive/6.0.8/amd64/iso-cd/debian-6.0.8-amd64-CD-1.iso",
     "iso_checksum": "d0ec1c64c00ff601995139dbacfb54109a23788f",

--- a/template/debian/debian71-i386.json
+++ b/template/debian/debian71-i386.json
@@ -37,7 +37,7 @@
   },
   {
     "vm_name": "debian71-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://cdimage.debian.org/cdimage/archive/7.1.0/i386/iso-dvd/debian-7.1.0-i386-DVD-1.iso",
     "iso_checksum": "cea26c7764188426da8c96bdf40eff138eb26fdc",

--- a/template/debian/debian71.json
+++ b/template/debian/debian71.json
@@ -37,7 +37,7 @@
   },
   {
     "vm_name": "debian71",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://cdimage.debian.org/cdimage/archive/7.1.0/amd64/iso-dvd/debian-7.1.0-amd64-DVD-1.iso",
     "iso_checksum": "1c55a7d938fd9cb5fdbd6c41543c90e89e6cff8c67ae263933c13775d8bf0be3",

--- a/template/debian/debian72-i386.json
+++ b/template/debian/debian72-i386.json
@@ -37,7 +37,7 @@
   },
   {
     "vm_name": "debian72-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://cdimage.debian.org/debian-cd/7.2.0/i386/iso-cd/debian-7.2.0-i386-CD-1.iso",
     "iso_checksum": "6044380d356b77e5b562b8b6faf9b5a3c16e41844ff738cb234daaf3101fab43",

--- a/template/debian/debian72.json
+++ b/template/debian/debian72.json
@@ -37,7 +37,7 @@
   },
   {
     "vm_name": "debian72",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://cdimage.debian.org/cdimage/release/current/amd64/iso-dvd/debian-7.2.0-amd64-DVD-1.iso",
     "iso_checksum": "5c926252b6dd4705d05bb4852e9a584ae5b3e7999b49d64a48e346714251466e",

--- a/template/debian/debian73-i386.json
+++ b/template/debian/debian73-i386.json
@@ -40,7 +40,7 @@
   },
   {
     "vm_name": "debian73-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "{{user `iso_url`}}",
     "iso_checksum": "{{user `iso_checksum`}}",

--- a/template/debian/debian73.json
+++ b/template/debian/debian73.json
@@ -40,7 +40,7 @@
   },
   {
     "vm_name": "debian73",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "{{user `iso_url`}}",
     "iso_checksum": "{{user `iso_checksum`}}",

--- a/template/fedora/fedora18-i386.json
+++ b/template/fedora/fedora18-i386.json
@@ -29,7 +29,7 @@
   },
   {
     "vm_name": "fedora18-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/fedora/releases/18/Fedora/i386/iso/Fedora-18-i386-DVD.iso",
     "iso_checksum": "a22e6ab7b0e5e93397e4a1d8d994693d0afb9ad46b1f47a4fe10bfbbc2e7f354",

--- a/template/fedora/fedora18.json
+++ b/template/fedora/fedora18.json
@@ -29,7 +29,7 @@
   },
   {
     "vm_name": "fedora18",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/fedora/releases/18/Fedora/x86_64/iso/Fedora-18-x86_64-DVD.iso",
     "iso_checksum": "91c5f0aca391acf76a047e284144f90d66d3d5f5dcd26b01f368a43236832c03",

--- a/template/fedora/fedora19-i386.json
+++ b/template/fedora/fedora19-i386.json
@@ -29,7 +29,7 @@
   },
   {
     "vm_name": "fedora19-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/fedora/releases/19/Fedora/i386/iso/Fedora-19-i386-DVD.iso",
     "iso_checksum": "0da29695c4f503e2b27350406c1ceb7a4e5b9b699ea722774368fd16ab277bce",

--- a/template/fedora/fedora19.json
+++ b/template/fedora/fedora19.json
@@ -29,7 +29,7 @@
   },
   {
     "vm_name": "fedora19",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://download.fedoraproject.org/pub/fedora/linux/releases/19/Fedora/x86_64/iso/Fedora-19-x86_64-DVD.iso",
     "iso_checksum": "6e7e263e607cfcadc90ea2ef5668aa3945d9eca596485a7a1f8a9f2478cc7084",

--- a/template/fedora/fedora20-i386.json
+++ b/template/fedora/fedora20-i386.json
@@ -29,7 +29,7 @@
   },
   {
     "vm_name": "fedora20-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/fedora/releases/test/20-Beta/Fedora/i386/iso/Fedora-20-Beta-i386-DVD.iso",
     "iso_checksum": "d98caa59fa72c4817e040060149ca3951aef6c16ccf485522527e7efa3ebbd74",

--- a/template/fedora/fedora20.json
+++ b/template/fedora/fedora20.json
@@ -29,7 +29,7 @@
   },
   {
     "vm_name": "fedora20",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://mirrors.kernel.org/fedora/releases/test/20-Beta/Fedora/x86_64/iso/Fedora-20-Beta-x86_64-DVD.iso",
     "iso_checksum": "04e76a36eb97d6fcdc35e6a2ecdb7b7631a4d220cf70cfbffd0f17db000ae3ac",

--- a/template/freebsd/freebsd91.json
+++ b/template/freebsd/freebsd91.json
@@ -37,7 +37,7 @@
   },
   {
     "vm_name": "freebsd91",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "guest_os_type": "FreeBSD_64",
     "http_directory": "http",
     "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/9.1/FreeBSD-9.1-RELEASE-amd64-disc1.iso",

--- a/template/opensuse/opensuse114.json
+++ b/template/opensuse/opensuse114.json
@@ -30,7 +30,7 @@
     },
     {
       "vm_name": "opensuse114",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "OpenSUSE_64",
       "http_directory": "http",
       "iso_url": "http://download.opensuse.org/distribution/11.4/iso/openSUSE-11.4-DVD-x86_64.iso",

--- a/template/oraclelinux/oracle510-i386.json
+++ b/template/oraclelinux/oracle510-i386.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle510-i386",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "../../iso/V40140-01.iso",
       "iso_checksum": "5a9216dd69f17b9dd8f64ed539629741",

--- a/template/oraclelinux/oracle510.json
+++ b/template/oraclelinux/oracle510.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle510",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "../../iso/V40139-01.iso",
       "iso_checksum": "1aa0a1246b1a55108abf20aa2bcac00e",

--- a/template/oraclelinux/oracle57-i386.json
+++ b/template/oraclelinux/oracle57-i386.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle57-i386",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/EL5/U7/i386/Enterprise-R5-U7-Server-i386-dvd.iso",
       "iso_checksum": "0800684248e6b36f38a606689e4759f8",

--- a/template/oraclelinux/oracle57.json
+++ b/template/oraclelinux/oracle57.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle57",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/EL5/U7/x86_64/Enterprise-R5-U7-Server-x86_64-dvd.iso",
       "iso_checksum": "04fcd6af234eebda71d8c336db050f42",

--- a/template/oraclelinux/oracle58-i386.json
+++ b/template/oraclelinux/oracle58-i386.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle58-i386",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/EL5/U8/i386/OracleLinux-R5-U8-Server-i386-dvd.iso",
       "iso_checksum": "e9f58baa2fc3cbd55e9b484d50071a9d",

--- a/template/oraclelinux/oracle58.json
+++ b/template/oraclelinux/oracle58.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle58",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/EL5/U8/x86_64/OracleLinux-R5-U8-Server-x86_64-dvd.iso",
       "iso_checksum": "1ec844c1090a417b741a9bf0d6dea240",

--- a/template/oraclelinux/oracle59-i386.json
+++ b/template/oraclelinux/oracle59-i386.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle59-i386",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/EL5/U9/i386/Enterprise-R5-U9-Server-i386-dvd.iso",
       "iso_checksum": "d6207fddf102c053dba05a29ed4770a3",

--- a/template/oraclelinux/oracle59.json
+++ b/template/oraclelinux/oracle59.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle59",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/EL5/U9/x86_64/Enterprise-R5-U9-Server-x86_64-dvd.iso",
       "iso_checksum": "80e5d40b7f8ddf06d3af70ee29e72b41",

--- a/template/oraclelinux/oracle61-i386.json
+++ b/template/oraclelinux/oracle61-i386.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle61-i386",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/OL6/U1/x86/OracleLinux-R6-U1-Server-i386-dvd.iso",
       "iso_checksum": "237419b43e949f2596b81cf9d63221cf16904d25c28ba0da9e0b3937517c6fa5",

--- a/template/oraclelinux/oracle61.json
+++ b/template/oraclelinux/oracle61.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "centos61",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/OL6/U1/x86_64/OracleLinux-R6-U1-Server-x86_64-dvd.iso",
       "iso_checksum": "8ecb3fdd8ad3a5f9802b483a3c688e4b779e6b6b6a09758831a825d6dfdc5be7",

--- a/template/oraclelinux/oracle62-i386.json
+++ b/template/oraclelinux/oracle62-i386.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle62-i386",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/OL6/U2/i386/OracleLinux-R6-U2-Server-i386-dvd.iso",
       "iso_checksum": "dd0d87cd0dbe0de9f56bd9f79cc07887e817d6b15c8e0a255845e7bd69fdedfd",

--- a/template/oraclelinux/oracle62.json
+++ b/template/oraclelinux/oracle62.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle62",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/OL6/U2/x86_64/OracleLinux-R6-U2-Server-x86_64-dvd.iso",
       "iso_checksum": "cf84edfe9167bc46195cb426b4ef74add6c81aa2",

--- a/template/oraclelinux/oracle63-i386.json
+++ b/template/oraclelinux/oracle63-i386.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle63-i386",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/OL6/U3/i386/OracleLinux-R6-U3-Server-i386-dvd.iso",
       "iso_checksum": "f43128d8f14bd22a16e78b473cc9a1decd251e70",

--- a/template/oraclelinux/oracle63.json
+++ b/template/oraclelinux/oracle63.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle63",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/OL6/U3/x86_64/OracleLinux-R6-U3-Server-x86_64-dvd.iso",
       "iso_checksum": "7daae91cc0437f6a98a4359ad9706d678a9f19de",

--- a/template/oraclelinux/oracle64-i386.json
+++ b/template/oraclelinux/oracle64-i386.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle64-i386",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/OL6/U4/i386/OracleLinux-R6-U4-Server-i386-dvd.iso",
       "iso_checksum": "afc350793e129e9dd0049c3fce282ff33cb623a9",

--- a/template/oraclelinux/oracle64.json
+++ b/template/oraclelinux/oracle64.json
@@ -29,7 +29,7 @@
     },
     {
       "vm_name": "oracle64",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "http_directory": "http",
       "iso_url": "http://mirrors.dotsrc.org/oracle-linux/OL6/U4/x86_64/OracleLinux-R6-U4-Server-x86_64-dvd.iso",
       "iso_checksum": "c1a5e99c63e9485d4a6abe35c20e01c5cabb9e33edbe3399db64fb2d6d3b42ec",

--- a/template/ubuntu/ubuntu1004-i386.json
+++ b/template/ubuntu/ubuntu1004-i386.json
@@ -46,7 +46,7 @@
   },
   {
     "vm_name": "ubuntu1004-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/10.04.4/ubuntu-10.04.4-server-i386.iso",
     "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",

--- a/template/ubuntu/ubuntu1004.json
+++ b/template/ubuntu/ubuntu1004.json
@@ -46,7 +46,7 @@
   },
   {
     "vm_name": "ubuntu1004",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/10.04.4/ubuntu-10.04.4-server-amd64.iso",
     "iso_checksum": "9b218654cdcdf9722171648c52f8a088",

--- a/template/ubuntu/ubuntu1204-docker.json
+++ b/template/ubuntu/ubuntu1204-docker.json
@@ -47,7 +47,7 @@
   },
   {
     "vm_name": "ubuntu1204-docker",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.3-server-amd64.iso",
     "iso_checksum": "61d5e67c70d97b33c13537461a0b153b41304ef412bb0e9d813bb157068c3c65",

--- a/template/ubuntu/ubuntu1204-i386.json
+++ b/template/ubuntu/ubuntu1204-i386.json
@@ -47,7 +47,7 @@
   },
   {
     "vm_name": "ubuntu1204-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.3-server-i386.iso",
     "iso_checksum": "2ec0e913959f6c2ba7a558e8bfa361428bb00e56",

--- a/template/ubuntu/ubuntu1204.json
+++ b/template/ubuntu/ubuntu1204.json
@@ -47,7 +47,7 @@
   },
   {
     "vm_name": "ubuntu1204",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.3-server-amd64.iso",
     "iso_checksum": "61d5e67c70d97b33c13537461a0b153b41304ef412bb0e9d813bb157068c3c65",

--- a/template/ubuntu/ubuntu1304-i386.json
+++ b/template/ubuntu/ubuntu1304-i386.json
@@ -47,7 +47,7 @@
   },
   {
     "vm_name": "ubuntu1304-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/13.04/ubuntu-13.04-server-i386.iso",
     "iso_checksum": "27bbe172d66d4ce634d10fd655e840f72fe56130",

--- a/template/ubuntu/ubuntu1304.json
+++ b/template/ubuntu/ubuntu1304.json
@@ -47,7 +47,7 @@
   },
   {
     "vm_name": "ubuntu1304",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/13.04/ubuntu-13.04-server-amd64.iso",
     "iso_checksum": "7d335ca541fc4945b674459cde7bffb9",

--- a/template/ubuntu/ubuntu1310-i386.json
+++ b/template/ubuntu/ubuntu1310-i386.json
@@ -47,7 +47,7 @@
   },
   {
     "vm_name": "ubuntu1310-i386",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/13.10/ubuntu-13.10-server-i386.iso",
     "iso_checksum": "2dda06d01d3ad495b53f7c03a4313b4af76a1c96",

--- a/template/ubuntu/ubuntu1310.json
+++ b/template/ubuntu/ubuntu1310.json
@@ -47,7 +47,7 @@
   },
   {
     "vm_name": "ubuntu1310",
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "http_directory": "http",
     "iso_url": "http://releases.ubuntu.com/13.10/ubuntu-13.10-server-amd64.iso",
     "iso_checksum": "5dd72c694c3a7e06a3b4dd651ca26cfc70985004",

--- a/template/windows2008r2/win2008r2-datacenter-cygwin.json
+++ b/template/windows2008r2/win2008r2-datacenter-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2008r2-datacenter-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2008_64",
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",

--- a/template/windows2008r2/win2008r2-datacenter.json
+++ b/template/windows2008r2/win2008r2-datacenter.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2008r2-datacenter",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2008_64",
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",

--- a/template/windows2008r2/win2008r2-enterprise-cygwin.json
+++ b/template/windows2008r2/win2008r2-enterprise-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2008r2-enterprise-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2008_64",
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",

--- a/template/windows2008r2/win2008r2-enterprise.json
+++ b/template/windows2008r2/win2008r2-enterprise.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2008r2-enterprise",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2008_64",
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",

--- a/template/windows2008r2/win2008r2-standard-cygwin.json
+++ b/template/windows2008r2/win2008r2-standard-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2008r2-standard-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2008_64",
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",

--- a/template/windows2008r2/win2008r2-standard.json
+++ b/template/windows2008r2/win2008r2-standard.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2008r2-standard",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2008_64",
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",

--- a/template/windows2008r2/win2008r2-web-cygwin.json
+++ b/template/windows2008r2/win2008r2-web-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2008r2-web-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2008_64",
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",

--- a/template/windows2008r2/win2008r2-web.json
+++ b/template/windows2008r2/win2008r2-web.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2008r2-web",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2008_64",
       "iso_url": "../../iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
       "iso_checksum": "8d397b69135d207452a78c3c3051339d",

--- a/template/windows2012/win2012-datacenter-cygwin.json
+++ b/template/windows2012/win2012-datacenter-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2012-datacenter-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2012_64",
       "iso_url": "../../iso/en_windows_server_2012_x64_dvd_915478.iso",
       "iso_checksum": "da91135483e24689bfdaf05d40301506",

--- a/template/windows2012/win2012-datacenter.json
+++ b/template/windows2012/win2012-datacenter.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2012-datacenter",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2012_64",
       "iso_url": "../../iso/en_windows_server_2012_x64_dvd_915478.iso",
       "iso_checksum": "da91135483e24689bfdaf05d40301506",

--- a/template/windows2012/win2012-standard-cygwin.json
+++ b/template/windows2012/win2012-standard-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2012-standard-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2012_64",
       "iso_url": "../../iso/en_windows_server_2012_x64_dvd_915478.iso",
       "iso_checksum": "da91135483e24689bfdaf05d40301506",

--- a/template/windows2012/win2012-standard.json
+++ b/template/windows2012/win2012-standard.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win2012-standard",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2012_64",
       "iso_url": "../../iso/en_windows_server_2012_x64_dvd_915478.iso",
       "iso_checksum": "da91135483e24689bfdaf05d40301506",

--- a/template/windows2012r2/win2012r2-datacenter-cygwin.json
+++ b/template/windows2012r2/win2012r2-datacenter-cygwin.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win2012r2-datacenter-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2012_64",
       "iso_url": "../../iso/en_windows_server_2012_r2_x64_dvd_2707946.iso",
       "iso_checksum": "0e7c09aab20dec3cd7eab236dab90e78",

--- a/template/windows2012r2/win2012r2-datacenter.json
+++ b/template/windows2012r2/win2012r2-datacenter.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win2012r2-datacenter",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2012_64",
       "iso_url": "../../iso/en_windows_server_2012_r2_x64_dvd_2707946.iso",
       "iso_checksum": "0e7c09aab20dec3cd7eab236dab90e78",

--- a/template/windows2012r2/win2012r2-standard-cygwin.json
+++ b/template/windows2012r2/win2012r2-standard-cygwin.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win2012r2-standard-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2012_64",
       "iso_url": "../../iso/en_windows_server_2012_r2_x64_dvd_2707946.iso",
       "iso_checksum": "0e7c09aab20dec3cd7eab236dab90e78",

--- a/template/windows2012r2/win2012r2-standard.json
+++ b/template/windows2012r2/win2012r2-standard.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win2012r2-standard",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows2012_64",
       "iso_url": "../../iso/en_windows_server_2012_r2_x64_dvd_2707946.iso",
       "iso_checksum": "0e7c09aab20dec3cd7eab236dab90e78",

--- a/template/windows7/win7x64-enterprise-cygwin.json
+++ b/template/windows7/win7x64-enterprise-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win7x64-enterprise-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows7_64",
       "iso_url": "../../iso/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651.iso",
       "iso_checksum": "6467c3875955df4514395f0afcaaa62a",

--- a/template/windows7/win7x64-enterprise.json
+++ b/template/windows7/win7x64-enterprise.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win7x64-enterprise",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows7_64",
       "iso_url": "../../iso/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651.iso",
       "iso_checksum": "6467c3875955df4514395f0afcaaa62a",

--- a/template/windows7/win7x64-pro-cygwin.json
+++ b/template/windows7/win7x64-pro-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win7x64-pro-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows7_64",
       "iso_url": "../../iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
       "iso_checksum": "3c394e66c208cfd641b976de10fe90b5",

--- a/template/windows7/win7x64-pro.json
+++ b/template/windows7/win7x64-pro.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win7x64-pro",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows7_64",
       "iso_url": "../../iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
       "iso_checksum": "3c394e66c208cfd641b976de10fe90b5",

--- a/template/windows7/win7x86-enterprise-cygwin.json
+++ b/template/windows7/win7x86-enterprise-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win7x86-enterprise-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows7",
       "iso_url": "../../iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
       "iso_checksum": "d6044be7093fb2737db63d340a1b2a03",

--- a/template/windows7/win7x86-enterprise.json
+++ b/template/windows7/win7x86-enterprise.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win7x86-enterprise",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows7",
       "iso_url": "../../iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
       "iso_checksum": "d6044be7093fb2737db63d340a1b2a03",

--- a/template/windows7/win7x86-pro-cygwin.json
+++ b/template/windows7/win7x86-pro-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win7x86-pro-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows7",
       "iso_url": "../../iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
       "iso_checksum": "f55d3916622dd4125be6336876559690",

--- a/template/windows7/win7x86-pro.json
+++ b/template/windows7/win7x86-pro.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win7x86-pro",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows7",
       "iso_url": "../../iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
       "iso_checksum": "f55d3916622dd4125be6336876559690",

--- a/template/windows8/win8x64-enterprise-cygwin.json
+++ b/template/windows8/win8x64-enterprise-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win8x64-enterprise-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8_64",
       "iso_url": "../../iso/en_windows_8_enterprise_x64_dvd_917522.iso",
       "iso_checksum": "27aa354b8088527ffcd32007b51b25bf",

--- a/template/windows8/win8x64-enterprise.json
+++ b/template/windows8/win8x64-enterprise.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win8x64-enterprise",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8_64",
       "iso_url": "../../iso/en_windows_8_enterprise_x64_dvd_917522.iso",
       "iso_checksum": "27aa354b8088527ffcd32007b51b25bf",

--- a/template/windows8/win8x64-pro-cygwin.json
+++ b/template/windows8/win8x64-pro-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win8x64-pro-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8_64",
       "iso_url": "../../iso/en_windows_8_x64_dvd_915440.iso",
       "iso_checksum": "0e8f2199fae18fe510c23426e68f675a",

--- a/template/windows8/win8x64-pro.json
+++ b/template/windows8/win8x64-pro.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win8x64-pro",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8_64",
       "iso_url": "../../iso/en_windows_8_x64_dvd_915440.iso",
       "iso_checksum": "0e8f2199fae18fe510c23426e68f675a",

--- a/template/windows8/win8x86-enterprise-cygwin.json
+++ b/template/windows8/win8x86-enterprise-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win8x86-enterpsie-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_enterprise_x86_dvd_917587.iso",
       "iso_checksum": "ad055cae50cef987586c51cc6cc3c62e",

--- a/template/windows8/win8x86-enterprise.json
+++ b/template/windows8/win8x86-enterprise.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win8x86-enterprise",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_enterprise_x86_dvd_917587.iso",
       "iso_checksum": "ad055cae50cef987586c51cc6cc3c62e",

--- a/template/windows8/win8x86-pro-cygwin.json
+++ b/template/windows8/win8x86-pro-cygwin.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win8x86-pro-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_x86_dvd_915417.iso",
       "iso_checksum": "4252407333706df89a0c654924dd3f06",

--- a/template/windows8/win8x86-pro.json
+++ b/template/windows8/win8x86-pro.json
@@ -33,7 +33,7 @@
     },
     {
       "vm_name": "win8x86-pro",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_x86_dvd_915417.iso",
       "iso_checksum": "4252407333706df89a0c654924dd3f06",

--- a/template/windows81/win81x64-enterprise-cygwin.json
+++ b/template/windows81/win81x64-enterprise-cygwin.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win81x64-enterprise-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8_64",
       "iso_url": "../../iso/en_windows_8_1_enterprise_x64_dvd_2971902.iso",
       "iso_checksum": "8e194185fcce4ea737f274ee9005ddf0",

--- a/template/windows81/win81x64-enterprise.json
+++ b/template/windows81/win81x64-enterprise.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win81x64-enterprise",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8_64",
       "iso_url": "../../iso/en_windows_8_1_enterprise_x64_dvd_2971902.iso",
       "iso_checksum": "8e194185fcce4ea737f274ee9005ddf0",

--- a/template/windows81/win81x64-pro-cygwin.json
+++ b/template/windows81/win81x64-pro-cygwin.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win81x64-pro-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8_64",
       "iso_url": "../../iso/en_windows_8_1_x64_dvd_2707217.iso",
       "iso_checksum": "f104b78019e86e74b149ae5e510f7be9",

--- a/template/windows81/win81x64-pro.json
+++ b/template/windows81/win81x64-pro.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win81x64-pro",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8_64",
       "iso_url": "../../iso/en_windows_8_1_x64_dvd_2707217.iso",
       "iso_checksum": "f104b78019e86e74b149ae5e510f7be9",

--- a/template/windows81/win81x86-enterprise-cygwin.json
+++ b/template/windows81/win81x86-enterprise-cygwin.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win81x86-enterprise-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_1_enterprise_x86_dvd_2972289.iso",
       "iso_checksum": "bf620a67b5dda1e18e9ce17d25711201",

--- a/template/windows81/win81x86-enterprise.json
+++ b/template/windows81/win81x86-enterprise.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win81x86-enterprise",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_1_enterprise_x86_dvd_2972289.iso",
       "iso_checksum": "bf620a67b5dda1e18e9ce17d25711201",

--- a/template/windows81/win81x86-pro-cygwin.json
+++ b/template/windows81/win81x86-pro-cygwin.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win81x86-pro-cygwin",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_1_x86_dvd_2707392.iso",
       "iso_checksum": "7dd36fea0d004acfedbdb3a5521ef5ff",

--- a/template/windows81/win81x86-pro.json
+++ b/template/windows81/win81x86-pro.json
@@ -34,7 +34,7 @@
     },
     {
       "vm_name": "win81x86-pro",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "Windows8",
       "iso_url": "../../iso/en_windows_8_1_x86_dvd_2707392.iso",
       "iso_checksum": "7dd36fea0d004acfedbdb3a5521ef5ff",


### PR DESCRIPTION
Using the latest packer (v0.5.0), until this change was made, you could not build any of the machines using VirtualBox by default.
