### PR TITLE
Fixes #33: start ssh daemon last

### DIFF
--- a/template/windows2008r2/floppy/cygwin.bat
+++ b/template/windows2008r2/floppy/cygwin.bat
@@ -54,6 +54,3 @@ for /D %%i in (%TEMP%\http*.*) do del /s /q "%%~i"
 
 echo ==^> Fixing corrupt recycle bin - see http://www.winhelponline.com/blog/fix-corrupted-recycle-bin-windows-7-vista/
 rd /s /q %SystemDrive%\$Recycle.bin
-
-echo ==^> Starting the ssh service
-net start sshd

--- a/template/windows2008r2/floppy/openssh.bat
+++ b/template/windows2008r2/floppy/openssh.bat
@@ -23,6 +23,8 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
+sc stop opensshd
+
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F

--- a/template/windows2008r2/floppy/zz-net-start-sshd.cmd
+++ b/template/windows2008r2/floppy/zz-net-start-sshd.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
+set SSH_SERVICE=
+
+sc query sshd
+if not errorlevel 1 set SSH_SERVICE=sshd
+
+sc query opensshd
+if not errorlevel 1 set SSH_SERVICE=opensshd
+
+echo ==^> Starting the %SSH_SERVICE% service
+
+sc start %SSH_SERVICE%

--- a/template/windows2008r2/floppy/zz-net-start-sshd.cmd
+++ b/template/windows2008r2/floppy/zz-net-start-sshd.cmd
@@ -1,12 +1,11 @@
-@echo off
 setlocal EnableDelayedExpansion EnableExtensions
 
 set SSH_SERVICE=
 
-sc query sshd
+sc query sshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=sshd
 
-sc query opensshd
+sc query opensshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=opensshd
 
 echo ==^> Starting the %SSH_SERVICE% service

--- a/template/windows2008r2/win2008r2-datacenter-cygwin.json
+++ b/template/windows2008r2/win2008r2-datacenter-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2008r2/win2008r2-datacenter.json
+++ b/template/windows2008r2/win2008r2-datacenter.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2008r2/win2008r2-enterprise-cygwin.json
+++ b/template/windows2008r2/win2008r2-enterprise-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2008r2/win2008r2-enterprise.json
+++ b/template/windows2008r2/win2008r2-enterprise.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2008r2/win2008r2-standard-cygwin.json
+++ b/template/windows2008r2/win2008r2-standard-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2008r2/win2008r2-standard.json
+++ b/template/windows2008r2/win2008r2-standard.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2008r2/win2008r2-web-cygwin.json
+++ b/template/windows2008r2/win2008r2-web-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2008r2/win2008r2-web.json
+++ b/template/windows2008r2/win2008r2-web.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -47,7 +48,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/opensshsshd.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2012/floppy/cygwin.bat
+++ b/template/windows2012/floppy/cygwin.bat
@@ -54,6 +54,3 @@ for /D %%i in (%TEMP%\http*.*) do del /s /q "%%~i"
 
 echo ==^> Fixing corrupt recycle bin - see http://www.winhelponline.com/blog/fix-corrupted-recycle-bin-windows-7-vista/
 rd /s /q %SystemDrive%\$Recycle.bin
-
-echo ==^> Starting the ssh service
-net start sshd

--- a/template/windows2012/floppy/openssh.bat
+++ b/template/windows2012/floppy/openssh.bat
@@ -23,6 +23,8 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
+sc stop opensshd
+
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F

--- a/template/windows2012/floppy/zz-net-start-sshd.cmd
+++ b/template/windows2012/floppy/zz-net-start-sshd.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
+set SSH_SERVICE=
+
+sc query sshd
+if not errorlevel 1 set SSH_SERVICE=sshd
+
+sc query opensshd
+if not errorlevel 1 set SSH_SERVICE=opensshd
+
+echo ==^> Starting the %SSH_SERVICE% service
+
+sc start %SSH_SERVICE%

--- a/template/windows2012/floppy/zz-net-start-sshd.cmd
+++ b/template/windows2012/floppy/zz-net-start-sshd.cmd
@@ -1,12 +1,11 @@
-@echo off
 setlocal EnableDelayedExpansion EnableExtensions
 
 set SSH_SERVICE=
 
-sc query sshd
+sc query sshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=sshd
 
-sc query opensshd
+sc query opensshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=opensshd
 
 echo ==^> Starting the %SSH_SERVICE% service

--- a/template/windows2012/win2012-datacenter-cygwin.json
+++ b/template/windows2012/win2012-datacenter-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2012/win2012-datacenter.json
+++ b/template/windows2012/win2012-datacenter.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2012/win2012-standard-cygwin.json
+++ b/template/windows2012/win2012-standard-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2012/win2012-standard.json
+++ b/template/windows2012/win2012-standard.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2012r2/floppy/cygwin.bat
+++ b/template/windows2012r2/floppy/cygwin.bat
@@ -54,6 +54,3 @@ for /D %%i in (%TEMP%\http*.*) do del /s /q "%%~i"
 
 echo ==^> Fixing corrupt recycle bin - see http://www.winhelponline.com/blog/fix-corrupted-recycle-bin-windows-7-vista/
 rd /s /q %SystemDrive%\$Recycle.bin
-
-echo ==^> Starting the ssh service
-net start sshd

--- a/template/windows2012r2/floppy/openssh.bat
+++ b/template/windows2012r2/floppy/openssh.bat
@@ -23,6 +23,8 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
+sc stop opensshd
+
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F

--- a/template/windows2012r2/floppy/zz-net-start-sshd.cmd
+++ b/template/windows2012r2/floppy/zz-net-start-sshd.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
+set SSH_SERVICE=
+
+sc query sshd
+if not errorlevel 1 set SSH_SERVICE=sshd
+
+sc query opensshd
+if not errorlevel 1 set SSH_SERVICE=opensshd
+
+echo ==^> Starting the %SSH_SERVICE% service
+
+sc start %SSH_SERVICE%

--- a/template/windows2012r2/floppy/zz-net-start-sshd.cmd
+++ b/template/windows2012r2/floppy/zz-net-start-sshd.cmd
@@ -1,12 +1,11 @@
-@echo off
 setlocal EnableDelayedExpansion EnableExtensions
 
 set SSH_SERVICE=
 
-sc query sshd
+sc query sshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=sshd
 
-sc query opensshd
+sc query opensshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=opensshd
 
 echo ==^> Starting the %SSH_SERVICE% service

--- a/template/windows2012r2/win2012r2-datacenter-cygwin.json
+++ b/template/windows2012r2/win2012r2-datacenter-cygwin.json
@@ -21,6 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/cygwin.bat"
       ],
       "tools_upload_flavor": "windows",
@@ -48,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2012r2/win2012r2-datacenter.json
+++ b/template/windows2012r2/win2012r2-datacenter.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2012r2/win2012r2-standard-cygwin.json
+++ b/template/windows2012r2/win2012r2-standard-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/passwordchange.bat",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows2012r2/win2012r2-standard.json
+++ b/template/windows2012r2/win2012r2-standard.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows7/floppy/cygwin.bat
+++ b/template/windows7/floppy/cygwin.bat
@@ -54,6 +54,3 @@ for /D %%i in (%TEMP%\http*.*) do del /s /q "%%~i"
 
 echo ==^> Fixing corrupt recycle bin - see http://www.winhelponline.com/blog/fix-corrupted-recycle-bin-windows-7-vista/
 rd /s /q %SystemDrive%\$Recycle.bin
-
-echo ==^> Starting the ssh service
-net start sshd

--- a/template/windows7/floppy/openssh.bat
+++ b/template/windows7/floppy/openssh.bat
@@ -23,6 +23,8 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
+sc stop opensshd
+
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F

--- a/template/windows7/floppy/zz-net-start-sshd.cmd
+++ b/template/windows7/floppy/zz-net-start-sshd.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
+set SSH_SERVICE=
+
+sc query sshd
+if not errorlevel 1 set SSH_SERVICE=sshd
+
+sc query opensshd
+if not errorlevel 1 set SSH_SERVICE=opensshd
+
+echo ==^> Starting the %SSH_SERVICE% service
+
+sc start %SSH_SERVICE%

--- a/template/windows7/floppy/zz-net-start-sshd.cmd
+++ b/template/windows7/floppy/zz-net-start-sshd.cmd
@@ -1,12 +1,11 @@
-@echo off
 setlocal EnableDelayedExpansion EnableExtensions
 
 set SSH_SERVICE=
 
-sc query sshd
+sc query sshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=sshd
 
-sc query opensshd
+sc query opensshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=opensshd
 
 echo ==^> Starting the %SSH_SERVICE% service

--- a/template/windows7/win7x64-enterprise-cygwin.json
+++ b/template/windows7/win7x64-enterprise-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -51,6 +52,7 @@
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows7/win7x64-enterprise.json
+++ b/template/windows7/win7x64-enterprise.json
@@ -21,7 +21,8 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -52,6 +53,7 @@
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/openssh.bat", 
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows7/win7x64-pro-cygwin.json
+++ b/template/windows7/win7x64-pro-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -51,6 +52,7 @@
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows7/win7x64-pro.json
+++ b/template/windows7/win7x64-pro.json
@@ -21,7 +21,8 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -51,6 +52,7 @@
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows7/win7x86-enterprise-cygwin.json
+++ b/template/windows7/win7x86-enterprise-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -51,6 +52,7 @@
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows7/win7x86-enterprise.json
+++ b/template/windows7/win7x86-enterprise.json
@@ -21,7 +21,8 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -51,6 +52,7 @@
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows7/win7x86-pro-cygwin.json
+++ b/template/windows7/win7x86-pro-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
-        "floppy/cygwinsshd.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -52,6 +53,7 @@
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows7/win7x86-pro.json
+++ b/template/windows7/win7x86-pro.json
@@ -21,7 +21,8 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -51,6 +52,7 @@
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows8/floppy/cygwin.bat
+++ b/template/windows8/floppy/cygwin.bat
@@ -54,6 +54,3 @@ for /D %%i in (%TEMP%\http*.*) do del /s /q "%%~i"
 
 echo ==^> Fixing corrupt recycle bin - see http://www.winhelponline.com/blog/fix-corrupted-recycle-bin-windows-7-vista/
 rd /s /q %SystemDrive%\$Recycle.bin
-
-echo ==^> Starting the ssh service
-net start sshd

--- a/template/windows8/floppy/openssh.bat
+++ b/template/windows8/floppy/openssh.bat
@@ -23,6 +23,8 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
+sc stop opensshd
+
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F

--- a/template/windows8/floppy/zz-net-start-sshd.cmd
+++ b/template/windows8/floppy/zz-net-start-sshd.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
+set SSH_SERVICE=
+
+sc query sshd
+if not errorlevel 1 set SSH_SERVICE=sshd
+
+sc query opensshd
+if not errorlevel 1 set SSH_SERVICE=opensshd
+
+echo ==^> Starting the %SSH_SERVICE% service
+
+sc start %SSH_SERVICE%

--- a/template/windows8/floppy/zz-net-start-sshd.cmd
+++ b/template/windows8/floppy/zz-net-start-sshd.cmd
@@ -1,12 +1,11 @@
-@echo off
 setlocal EnableDelayedExpansion EnableExtensions
 
 set SSH_SERVICE=
 
-sc query sshd
+sc query sshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=sshd
 
-sc query opensshd
+sc query opensshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=opensshd
 
 echo ==^> Starting the %SSH_SERVICE% service

--- a/template/windows8/win8x64-enterprise-cygwin.json
+++ b/template/windows8/win8x64-enterprise-cygwin.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows8/win8x64-enterprise.json
+++ b/template/windows8/win8x64-enterprise.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows8/win8x64-pro-cygwin.json
+++ b/template/windows8/win8x64-pro-cygwin.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -47,6 +48,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows8/win8x64-pro.json
+++ b/template/windows8/win8x64-pro.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows8/win8x86-enterprise-cygwin.json
+++ b/template/windows8/win8x86-enterprise-cygwin.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows8/win8x86-enterprise.json
+++ b/template/windows8/win8x86-enterprise.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows8/win8x86-pro-cygwin.json
+++ b/template/windows8/win8x86-pro-cygwin.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows8/win8x86-pro.json
+++ b/template/windows8/win8x86-pro.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -48,6 +49,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows81/floppy/cygwin.bat
+++ b/template/windows81/floppy/cygwin.bat
@@ -54,6 +54,3 @@ for /D %%i in (%TEMP%\http*.*) do del /s /q "%%~i"
 
 echo ==^> Fixing corrupt recycle bin - see http://www.winhelponline.com/blog/fix-corrupted-recycle-bin-windows-7-vista/
 rd /s /q %SystemDrive%\$Recycle.bin
-
-echo ==^> Starting the ssh service
-net start sshd

--- a/template/windows81/floppy/openssh.bat
+++ b/template/windows81/floppy/openssh.bat
@@ -23,6 +23,8 @@ echo ==^> Download complete
 echo ==^> Installing "%OPENSSH_EXE%"
 cmd /c "%OPENSSH_EXE%" /S /port=22 /privsep=1 /password=D@rj33l1ng
 
+sc stop opensshd
+
 echo ==^> Ensuring vagrant can login
 mkdir "%USERPROFILE%\.ssh"
 cmd /c %windir%\System32\icacls.exe "%USERPROFILE%" /grant %USERNAME%:(OI)(CI)F

--- a/template/windows81/floppy/zz-net-start-sshd.cmd
+++ b/template/windows81/floppy/zz-net-start-sshd.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
+set SSH_SERVICE=
+
+sc query sshd
+if not errorlevel 1 set SSH_SERVICE=sshd
+
+sc query opensshd
+if not errorlevel 1 set SSH_SERVICE=opensshd
+
+echo ==^> Starting the %SSH_SERVICE% service
+
+sc start %SSH_SERVICE%

--- a/template/windows81/floppy/zz-net-start-sshd.cmd
+++ b/template/windows81/floppy/zz-net-start-sshd.cmd
@@ -1,12 +1,11 @@
-@echo off
 setlocal EnableDelayedExpansion EnableExtensions
 
 set SSH_SERVICE=
 
-sc query sshd
+sc query sshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=sshd
 
-sc query opensshd
+sc query opensshd >nul 2>nul
 if not errorlevel 1 set SSH_SERVICE=opensshd
 
 echo ==^> Starting the %SSH_SERVICE% service

--- a/template/windows81/win81x64-enterprise-cygwin.json
+++ b/template/windows81/win81x64-enterprise-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows81/win81x64-enterprise.json
+++ b/template/windows81/win81x64-enterprise.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows81/win81x64-pro-cygwin.json
+++ b/template/windows81/win81x64-pro-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows81/win81x64-pro.json
+++ b/template/windows81/win81x64-pro.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "tools_upload_path": "/cygdrive/c/Users/vagrant/{{.Flavor}}.iso",
@@ -50,6 +51,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "guest_additions_path": "/cygdrive/c/Users/vagrant/VBoxGuestAdditions.iso",

--- a/template/windows81/win81x86-enterprise-cygwin.json
+++ b/template/windows81/win81x86-enterprise-cygwin.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows81/win81x86-enterprise.json
+++ b/template/windows81/win81x86-enterprise.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,7 +50,9 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
-        "floppy/oracle-cert.cer"],
+        "floppy/zz-net-start-sshd.cmd",
+        "floppy/oracle-cert.cer"
+      ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
       "disk_size": 40960,
       "vboxmanage": [

--- a/template/windows81/win81x86-pro-cygwin.json
+++ b/template/windows81/win81x86-pro-cygwin.json
@@ -20,7 +20,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/cygwin.bat"
+        "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "ssh_wait_timeout": "10000s",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",

--- a/template/windows81/win81x86-pro.json
+++ b/template/windows81/win81x86-pro.json
@@ -21,7 +21,8 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
-        "floppy/openssh.bat"
+        "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd"
       ],
       "tools_upload_flavor": "windows",
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",
@@ -49,6 +50,7 @@
         "floppy/powerconfig.bat",
         "floppy/passwordchange.bat",
         "floppy/openssh.bat",
+        "floppy/zz-net-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
       "shutdown_command": "shutdown /s /t 1 /f /d p:4:1 /c 'Packer Shutdown'",


### PR DESCRIPTION
Start ssh daemon after all other scripts are run, to avoid premature shutdown (floppy/zz-net-start-sshd.cmd)
