### PR TITLE
Fixes #40 Populate environment variables that Cygwin removes

### DIFF
--- a/template/windows2008r2/floppy/cygwin.bat
+++ b/template/windows2008r2/floppy/cygwin.bat
@@ -38,15 +38,9 @@ echo ==^> Opening firewall port 22 for the sshd service
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%CYGWIN_HOME%\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
 
-echo ==^> Make user home directories default to their windows profile directory
-bash -c "ln -s ""$(dirname $(cygpath -D))"" /home/$USERNAME"
-bash -c "mkpasswd -l -p ""$(cygpath -H)"" >/etc/passwd"
+set CYGWIN=ntsecbinmode mintty nodosfilewarning
 
-echo ==^> Creating /etc/group (required by sshd)
-bash -c "mkgroup -l >/etc/group"
-
-echo ==^> set up sshd config files
-bash -c "ssh-host-config -y -c ""ntsecbinmode mintty nodosfilewarning"" -w ""abc&&123!!"" "
+bash a:/cygwin.sh "abc&&123!!"
 
 echo ==^> Deleting the Cygwin installer and downloaded packages
 del "%CYGWIN_SETUP_LOCAL_PATH%"

--- a/template/windows2008r2/floppy/cygwin.sh
+++ b/template/windows2008r2/floppy/cygwin.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+export CYGWIN="ntsecbinmode mintty nodosfilewarning"
+
+echo '==> Make user home directories default to their windows profile directory'
+
+ln -s "$(dirname $(cygpath -D))" /home/$USERNAME
+
+mkpasswd -l -p "$(cygpath -H)" >/etc/passwd
+
+echo '==> Creating /etc/group (required by sshd)'
+mkgroup -l >/etc/group
+
+echo "==> set up host's ssh config files"
+
+ssh-host-config -y -c "$CYGWIN" -w $1
+
+chmod a+w /etc/sshd_config
+
+sed -i -e 's/StrictModes yes/StrictModes no/i' /etc/sshd_config
+sed -i -e 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/i' /etc/sshd_config
+sed -i -e 's/#PermitUserEnvironment no/PermitUserEnvironment yes/i' /etc/sshd_config
+sed -i -e 's/#UseDNS yes/UseDNS no/i' /etc/sshd_config
+
+chmod go-w /etc/sshd_config
+
+echo "==> set up user's ssh config files"
+
+ssh-user-config -y -p ''
+
+sed -i.bak -e 's/^TMP/#TMP/; s/^TEMP/#TEMP/; s/^unset TMP/#unset TMP/' /etc/profile
+
+SSHENV=$SYSTEMDRIVE/Users/$USERNAME/.ssh/environment
+
+echo "APPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Roaming" >>$SSHENV
+echo "CommonProgramFiles=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+echo "LOCALAPPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local" >>$SSHENV
+echo "ProgramData=$SYSTEMDRIVE\\ProgramData" >>$SSHENV
+echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
+echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
+echo "SESSIONNAME=Console" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+# to override "cyg_server":
+echo "USERNAME=$USERNAME" >>$SSHENV
+
+if [ -d "$SYSTEMDRIVE/Program Files (x86)" ];then
+  echo "CommonProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)\\Common Files" >>$SSHENV
+  echo "CommonProgramW6432=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+  echo "ProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)" >>$SSHENV
+  echo "ProgramW6432=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+fi

--- a/template/windows2008r2/floppy/cygwin.sh
+++ b/template/windows2008r2/floppy/cygwin.sh
@@ -40,8 +40,8 @@ echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
 echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
 echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
 echo "SESSIONNAME=Console" >>$SSHENV
-echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
-echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
 # to override "cyg_server":
 echo "USERNAME=$USERNAME" >>$SSHENV
 

--- a/template/windows2008r2/floppy/openssh.bat
+++ b/template/windows2008r2/floppy/openssh.bat
@@ -33,12 +33,33 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\passwd') | Foreach
 echo ==^> Fixing opensshd to not be strict
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'StrictModes yes', 'StrictModes no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PubkeyAuthentication yes', 'PubkeyAuthentication yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PermitUserEnvironment no', 'PermitUserEnvironment yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#UseDNS yes', 'UseDNS no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'Banner /etc/banner.txt', '#Banner /etc/banner.txt' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
 cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'APPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Roaming'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles=%SystemDrive%\Program Files\Common Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'LOCALAPPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Local'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramData=%SystemDrive%\ProgramData'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles=%SystemDrive%\Program Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PSModulePath=%SystemDrive%\Windows\system32\WindowsPowerShell\v1.0\Modules\'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PUBLIC=%SystemDrive%\Users\Public'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'SESSIONNAME=Console'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TEMP=%windir%\Temp'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TMP=%windir%\Temp'"
+:: to override "cyg_server":
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'USERNAME=%USERNAME%'"
+
+if exist "%SystemDrive%\Program Files (x86)" (
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles(x86)=%SystemDrive%\Program Files (x86)\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramW6432=%SystemDrive%\Program Files\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles(x86)=%SystemDrive%\Program Files (x86)'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramW6432=%SystemDrive%\Program Files'"
+)
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows2008r2/win2008r2-datacenter-cygwin.json
+++ b/template/windows2008r2/win2008r2-datacenter-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows2008r2/win2008r2-datacenter-cygwin.json
+++ b/template/windows2008r2/win2008r2-datacenter-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows2008r2/win2008r2-enterprise-cygwin.json
+++ b/template/windows2008r2/win2008r2-enterprise-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2008r2-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2008r2-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows2008r2/win2008r2-enterprise-cygwin.json
+++ b/template/windows2008r2/win2008r2-enterprise-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows2008r2/win2008r2-standard-cygwin.json
+++ b/template/windows2008r2/win2008r2-standard-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,9 +46,9 @@
       "disk_size": 40960,
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows2008r2/win2008r2-standard-cygwin.json
+++ b/template/windows2008r2/win2008r2-standard-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -47,6 +48,7 @@
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows2008r2/win2008r2-web-cygwin.json
+++ b/template/windows2008r2/win2008r2-web-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows2008r2/win2008r2-web-cygwin.json
+++ b/template/windows2008r2/win2008r2-web-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2008r2-web/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2008r2-web/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows2012/floppy/cygwin.bat
+++ b/template/windows2012/floppy/cygwin.bat
@@ -38,15 +38,9 @@ echo ==^> Opening firewall port 22 for the sshd service
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%CYGWIN_HOME%\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
 
-echo ==^> Make user home directories default to their windows profile directory
-bash -c "ln -s ""$(dirname $(cygpath -D))"" /home/$USERNAME"
-bash -c "mkpasswd -l -p ""$(cygpath -H)"" >/etc/passwd"
+set CYGWIN=ntsecbinmode mintty nodosfilewarning
 
-echo ==^> Creating /etc/group (required by sshd)
-bash -c "mkgroup -l >/etc/group"
-
-echo ==^> set up sshd config files
-bash -c "ssh-host-config -y -c ""ntsecbinmode mintty nodosfilewarning"" -w ""abc&&123!!"" "
+bash a:/cygwin.sh "abc&&123!!"
 
 echo ==^> Deleting the Cygwin installer and downloaded packages
 del "%CYGWIN_SETUP_LOCAL_PATH%"

--- a/template/windows2012/floppy/cygwin.sh
+++ b/template/windows2012/floppy/cygwin.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+export CYGWIN="ntsecbinmode mintty nodosfilewarning"
+
+echo '==> Make user home directories default to their windows profile directory'
+
+ln -s "$(dirname $(cygpath -D))" /home/$USERNAME
+
+mkpasswd -l -p "$(cygpath -H)" >/etc/passwd
+
+echo '==> Creating /etc/group (required by sshd)'
+mkgroup -l >/etc/group
+
+echo "==> set up host's ssh config files"
+
+ssh-host-config -y -c "$CYGWIN" -w $1
+
+chmod a+w /etc/sshd_config
+
+sed -i -e 's/StrictModes yes/StrictModes no/i' /etc/sshd_config
+sed -i -e 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/i' /etc/sshd_config
+sed -i -e 's/#PermitUserEnvironment no/PermitUserEnvironment yes/i' /etc/sshd_config
+sed -i -e 's/#UseDNS yes/UseDNS no/i' /etc/sshd_config
+
+chmod go-w /etc/sshd_config
+
+echo "==> set up user's ssh config files"
+
+ssh-user-config -y -p ''
+
+sed -i.bak -e 's/^TMP/#TMP/; s/^TEMP/#TEMP/; s/^unset TMP/#unset TMP/' /etc/profile
+
+SSHENV=$SYSTEMDRIVE/Users/$USERNAME/.ssh/environment
+
+echo "APPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Roaming" >>$SSHENV
+echo "CommonProgramFiles=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+echo "LOCALAPPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local" >>$SSHENV
+echo "ProgramData=$SYSTEMDRIVE\\ProgramData" >>$SSHENV
+echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
+echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
+echo "SESSIONNAME=Console" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+# to override "cyg_server":
+echo "USERNAME=$USERNAME" >>$SSHENV
+
+if [ -d "$SYSTEMDRIVE/Program Files (x86)" ];then
+  echo "CommonProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)\\Common Files" >>$SSHENV
+  echo "CommonProgramW6432=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+  echo "ProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)" >>$SSHENV
+  echo "ProgramW6432=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+fi

--- a/template/windows2012/floppy/cygwin.sh
+++ b/template/windows2012/floppy/cygwin.sh
@@ -40,8 +40,8 @@ echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
 echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
 echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
 echo "SESSIONNAME=Console" >>$SSHENV
-echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
-echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
 # to override "cyg_server":
 echo "USERNAME=$USERNAME" >>$SSHENV
 

--- a/template/windows2012/floppy/openssh.bat
+++ b/template/windows2012/floppy/openssh.bat
@@ -33,12 +33,33 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\passwd') | Foreach
 echo ==^> Fixing opensshd to not be strict
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'StrictModes yes', 'StrictModes no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PubkeyAuthentication yes', 'PubkeyAuthentication yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PermitUserEnvironment no', 'PermitUserEnvironment yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#UseDNS yes', 'UseDNS no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'Banner /etc/banner.txt', '#Banner /etc/banner.txt' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
 cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'APPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Roaming'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles=%SystemDrive%\Program Files\Common Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'LOCALAPPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Local'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramData=%SystemDrive%\ProgramData'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles=%SystemDrive%\Program Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PSModulePath=%SystemDrive%\Windows\system32\WindowsPowerShell\v1.0\Modules\'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PUBLIC=%SystemDrive%\Users\Public'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'SESSIONNAME=Console'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TEMP=%windir%\Temp'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TMP=%windir%\Temp'"
+:: to override "cyg_server":
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'USERNAME=%USERNAME%'"
+
+if exist "%SystemDrive%\Program Files (x86)" (
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles(x86)=%SystemDrive%\Program Files (x86)\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramW6432=%SystemDrive%\Program Files\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles(x86)=%SystemDrive%\Program Files (x86)'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramW6432=%SystemDrive%\Program Files'"
+)
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows2012/win2012-datacenter-cygwin.json
+++ b/template/windows2012/win2012-datacenter-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows2012/win2012-datacenter-cygwin.json
+++ b/template/windows2012/win2012-datacenter-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2012-datacenter/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2012-datacenter/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows2012/win2012-standard-cygwin.json
+++ b/template/windows2012/win2012-standard-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows2012/win2012-standard-cygwin.json
+++ b/template/windows2012/win2012-standard-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2012-standard/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2012-standard/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows2012r2/floppy/cygwin.bat
+++ b/template/windows2012r2/floppy/cygwin.bat
@@ -38,15 +38,9 @@ echo ==^> Opening firewall port 22 for the sshd service
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%CYGWIN_HOME%\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
 
-echo ==^> Make user home directories default to their windows profile directory
-bash -c "ln -s ""$(dirname $(cygpath -D))"" /home/$USERNAME"
-bash -c "mkpasswd -l -p ""$(cygpath -H)"" >/etc/passwd"
+set CYGWIN=ntsecbinmode mintty nodosfilewarning
 
-echo ==^> Creating /etc/group (required by sshd)
-bash -c "mkgroup -l >/etc/group"
-
-echo ==^> set up sshd config files
-bash -c "ssh-host-config -y -c ""ntsecbinmode mintty nodosfilewarning"" -w ""abc&&123!!"" "
+bash a:/cygwin.sh "abc&&123!!"
 
 echo ==^> Deleting the Cygwin installer and downloaded packages
 del "%CYGWIN_SETUP_LOCAL_PATH%"

--- a/template/windows2012r2/floppy/cygwin.sh
+++ b/template/windows2012r2/floppy/cygwin.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+export CYGWIN="ntsecbinmode mintty nodosfilewarning"
+
+echo '==> Make user home directories default to their windows profile directory'
+
+ln -s "$(dirname $(cygpath -D))" /home/$USERNAME
+
+mkpasswd -l -p "$(cygpath -H)" >/etc/passwd
+
+echo '==> Creating /etc/group (required by sshd)'
+mkgroup -l >/etc/group
+
+echo "==> set up host's ssh config files"
+
+ssh-host-config -y -c "$CYGWIN" -w $1
+
+chmod a+w /etc/sshd_config
+
+sed -i -e 's/StrictModes yes/StrictModes no/i' /etc/sshd_config
+sed -i -e 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/i' /etc/sshd_config
+sed -i -e 's/#PermitUserEnvironment no/PermitUserEnvironment yes/i' /etc/sshd_config
+sed -i -e 's/#UseDNS yes/UseDNS no/i' /etc/sshd_config
+
+chmod go-w /etc/sshd_config
+
+echo "==> set up user's ssh config files"
+
+ssh-user-config -y -p ''
+
+sed -i.bak -e 's/^TMP/#TMP/; s/^TEMP/#TEMP/; s/^unset TMP/#unset TMP/' /etc/profile
+
+SSHENV=$SYSTEMDRIVE/Users/$USERNAME/.ssh/environment
+
+echo "APPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Roaming" >>$SSHENV
+echo "CommonProgramFiles=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+echo "LOCALAPPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local" >>$SSHENV
+echo "ProgramData=$SYSTEMDRIVE\\ProgramData" >>$SSHENV
+echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
+echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
+echo "SESSIONNAME=Console" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+# to override "cyg_server":
+echo "USERNAME=$USERNAME" >>$SSHENV
+
+if [ -d "$SYSTEMDRIVE/Program Files (x86)" ];then
+  echo "CommonProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)\\Common Files" >>$SSHENV
+  echo "CommonProgramW6432=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+  echo "ProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)" >>$SSHENV
+  echo "ProgramW6432=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+fi

--- a/template/windows2012r2/floppy/cygwin.sh
+++ b/template/windows2012r2/floppy/cygwin.sh
@@ -40,8 +40,8 @@ echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
 echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
 echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
 echo "SESSIONNAME=Console" >>$SSHENV
-echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
-echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
 # to override "cyg_server":
 echo "USERNAME=$USERNAME" >>$SSHENV
 

--- a/template/windows2012r2/floppy/openssh.bat
+++ b/template/windows2012r2/floppy/openssh.bat
@@ -33,12 +33,33 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\passwd') | Foreach
 echo ==^> Fixing opensshd to not be strict
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'StrictModes yes', 'StrictModes no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PubkeyAuthentication yes', 'PubkeyAuthentication yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PermitUserEnvironment no', 'PermitUserEnvironment yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#UseDNS yes', 'UseDNS no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'Banner /etc/banner.txt', '#Banner /etc/banner.txt' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
 cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'APPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Roaming'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles=%SystemDrive%\Program Files\Common Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'LOCALAPPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Local'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramData=%SystemDrive%\ProgramData'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles=%SystemDrive%\Program Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PSModulePath=%SystemDrive%\Windows\system32\WindowsPowerShell\v1.0\Modules\'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PUBLIC=%SystemDrive%\Users\Public'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'SESSIONNAME=Console'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TEMP=%windir%\Temp'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TMP=%windir%\Temp'"
+:: to override "cyg_server":
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'USERNAME=%USERNAME%'"
+
+if exist "%SystemDrive%\Program Files (x86)" (
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles(x86)=%SystemDrive%\Program Files (x86)\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramW6432=%SystemDrive%\Program Files\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles(x86)=%SystemDrive%\Program Files (x86)'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramW6432=%SystemDrive%\Program Files'"
+)
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows2012r2/win2012r2-datacenter-cygwin.json
+++ b/template/windows2012r2/win2012r2-datacenter-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2012r2-datacenter/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
+        "floppy/cygwin.sh",
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows2012r2/win2012r2-datacenter-cygwin.json
+++ b/template/windows2012r2/win2012r2-datacenter-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
       "floppy_files": [
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -65,10 +67,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows2012r2/win2012r2-standard-cygwin.json
+++ b/template/windows2012r2/win2012r2-standard-cygwin.json
@@ -19,9 +19,9 @@
       "floppy_files": [
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/cygwin.bat"
       ],
       "tools_upload_flavor": "windows",
@@ -46,9 +46,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win2012r2-standard/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows2012r2/win2012r2-standard-cygwin.json
+++ b/template/windows2012r2/win2012r2-standard-cygwin.json
@@ -21,6 +21,7 @@
         "floppy/00-run-all-scripts.cmd",
         "floppy/passwordchange.bat",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/cygwin.bat"
       ],
       "tools_upload_flavor": "windows",
@@ -47,6 +48,7 @@
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -66,10 +68,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows7/floppy/cygwin.bat
+++ b/template/windows7/floppy/cygwin.bat
@@ -38,15 +38,9 @@ echo ==^> Opening firewall port 22 for the sshd service
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%CYGWIN_HOME%\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
 
-echo ==^> Make user home directories default to their windows profile directory
-bash -c "ln -s ""$(dirname $(cygpath -D))"" /home/$USERNAME"
-bash -c "mkpasswd -l -p ""$(cygpath -H)"" >/etc/passwd"
+set CYGWIN=ntsecbinmode mintty nodosfilewarning
 
-echo ==^> Creating /etc/group (required by sshd)
-bash -c "mkgroup -l >/etc/group"
-
-echo ==^> set up sshd config files
-bash -c "ssh-host-config -y -c ""ntsecbinmode mintty nodosfilewarning"" -w ""abc&&123!!"" "
+bash a:/cygwin.sh "abc&&123!!"
 
 echo ==^> Deleting the Cygwin installer and downloaded packages
 del "%CYGWIN_SETUP_LOCAL_PATH%"

--- a/template/windows7/floppy/cygwin.sh
+++ b/template/windows7/floppy/cygwin.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+export CYGWIN="ntsecbinmode mintty nodosfilewarning"
+
+echo '==> Make user home directories default to their windows profile directory'
+
+ln -s "$(dirname $(cygpath -D))" /home/$USERNAME
+
+mkpasswd -l -p "$(cygpath -H)" >/etc/passwd
+
+echo '==> Creating /etc/group (required by sshd)'
+mkgroup -l >/etc/group
+
+echo "==> set up host's ssh config files"
+
+ssh-host-config -y -c "$CYGWIN" -w $1
+
+chmod a+w /etc/sshd_config
+
+sed -i -e 's/StrictModes yes/StrictModes no/i' /etc/sshd_config
+sed -i -e 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/i' /etc/sshd_config
+sed -i -e 's/#PermitUserEnvironment no/PermitUserEnvironment yes/i' /etc/sshd_config
+sed -i -e 's/#UseDNS yes/UseDNS no/i' /etc/sshd_config
+
+chmod go-w /etc/sshd_config
+
+echo "==> set up user's ssh config files"
+
+ssh-user-config -y -p ''
+
+sed -i.bak -e 's/^TMP/#TMP/; s/^TEMP/#TEMP/; s/^unset TMP/#unset TMP/' /etc/profile
+
+SSHENV=$SYSTEMDRIVE/Users/$USERNAME/.ssh/environment
+
+echo "APPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Roaming" >>$SSHENV
+echo "CommonProgramFiles=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+echo "LOCALAPPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local" >>$SSHENV
+echo "ProgramData=$SYSTEMDRIVE\\ProgramData" >>$SSHENV
+echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
+echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
+echo "SESSIONNAME=Console" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+# to override "cyg_server":
+echo "USERNAME=$USERNAME" >>$SSHENV
+
+if [ -d "$SYSTEMDRIVE/Program Files (x86)" ];then
+  echo "CommonProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)\\Common Files" >>$SSHENV
+  echo "CommonProgramW6432=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+  echo "ProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)" >>$SSHENV
+  echo "ProgramW6432=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+fi

--- a/template/windows7/floppy/cygwin.sh
+++ b/template/windows7/floppy/cygwin.sh
@@ -40,8 +40,8 @@ echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
 echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
 echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
 echo "SESSIONNAME=Console" >>$SSHENV
-echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
-echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
 # to override "cyg_server":
 echo "USERNAME=$USERNAME" >>$SSHENV
 

--- a/template/windows7/floppy/openssh.bat
+++ b/template/windows7/floppy/openssh.bat
@@ -33,12 +33,33 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\passwd') | Foreach
 echo ==^> Fixing opensshd to not be strict
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'StrictModes yes', 'StrictModes no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PubkeyAuthentication yes', 'PubkeyAuthentication yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PermitUserEnvironment no', 'PermitUserEnvironment yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#UseDNS yes', 'UseDNS no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'Banner /etc/banner.txt', '#Banner /etc/banner.txt' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
 cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'APPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Roaming'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles=%SystemDrive%\Program Files\Common Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'LOCALAPPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Local'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramData=%SystemDrive%\ProgramData'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles=%SystemDrive%\Program Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PSModulePath=%SystemDrive%\Windows\system32\WindowsPowerShell\v1.0\Modules\'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PUBLIC=%SystemDrive%\Users\Public'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'SESSIONNAME=Console'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TEMP=%windir%\Temp'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TMP=%windir%\Temp'"
+:: to override "cyg_server":
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'USERNAME=%USERNAME%'"
+
+if exist "%SystemDrive%\Program Files (x86)" (
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles(x86)=%SystemDrive%\Program Files (x86)\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramW6432=%SystemDrive%\Program Files\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles(x86)=%SystemDrive%\Program Files (x86)'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramW6432=%SystemDrive%\Program Files'"
+)
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows7/win7x64-enterprise-cygwin.json
+++ b/template/windows7/win7x64-enterprise-cygwin.json
@@ -19,8 +19,8 @@
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat"
       ],
@@ -49,8 +49,8 @@
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows7/win7x64-enterprise-cygwin.json
+++ b/template/windows7/win7x64-enterprise-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat"
@@ -48,6 +49,7 @@
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
@@ -68,10 +70,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows7/win7x64-pro-cygwin.json
+++ b/template/windows7/win7x64-pro-cygwin.json
@@ -19,8 +19,8 @@
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat"
       ],
@@ -49,8 +49,8 @@
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows7/win7x64-pro-cygwin.json
+++ b/template/windows7/win7x64-pro-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat"
@@ -48,6 +49,7 @@
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
@@ -68,10 +70,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows7/win7x86-enterprise-cygwin.json
+++ b/template/windows7/win7x86-enterprise-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat"
@@ -48,6 +49,7 @@
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
@@ -68,10 +70,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows7/win7x86-enterprise-cygwin.json
+++ b/template/windows7/win7x86-enterprise-cygwin.json
@@ -19,8 +19,8 @@
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat"
       ],
@@ -49,8 +49,8 @@
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows7/win7x86-pro-cygwin.json
+++ b/template/windows7/win7x86-pro-cygwin.json
@@ -19,8 +19,8 @@
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
         "floppy/networkprompt.bat",
         "floppy/cygwinsshd.bat"
       ],
@@ -50,8 +50,8 @@
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows7/win7x86-pro-cygwin.json
+++ b/template/windows7/win7x86-pro-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwinsshd.bat"
@@ -49,6 +50,7 @@
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/networkprompt.bat",
         "floppy/cygwin.bat",
@@ -69,10 +71,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows8/floppy/cygwin.bat
+++ b/template/windows8/floppy/cygwin.bat
@@ -38,15 +38,9 @@ echo ==^> Opening firewall port 22 for the sshd service
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%CYGWIN_HOME%\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
 
-echo ==^> Make user home directories default to their windows profile directory
-bash -c "ln -s ""$(dirname $(cygpath -D))"" /home/$USERNAME"
-bash -c "mkpasswd -l -p ""$(cygpath -H)"" >/etc/passwd"
+set CYGWIN=ntsecbinmode mintty nodosfilewarning
 
-echo ==^> Creating /etc/group (required by sshd)
-bash -c "mkgroup -l >/etc/group"
-
-echo ==^> set up sshd config files
-bash -c "ssh-host-config -y -c ""ntsecbinmode mintty nodosfilewarning"" -w ""abc&&123!!"" "
+bash a:/cygwin.sh "abc&&123!!"
 
 echo ==^> Deleting the Cygwin installer and downloaded packages
 del "%CYGWIN_SETUP_LOCAL_PATH%"

--- a/template/windows8/floppy/cygwin.sh
+++ b/template/windows8/floppy/cygwin.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+export CYGWIN="ntsecbinmode mintty nodosfilewarning"
+
+echo '==> Make user home directories default to their windows profile directory'
+
+ln -s "$(dirname $(cygpath -D))" /home/$USERNAME
+
+mkpasswd -l -p "$(cygpath -H)" >/etc/passwd
+
+echo '==> Creating /etc/group (required by sshd)'
+mkgroup -l >/etc/group
+
+echo "==> set up host's ssh config files"
+
+ssh-host-config -y -c "$CYGWIN" -w $1
+
+chmod a+w /etc/sshd_config
+
+sed -i -e 's/StrictModes yes/StrictModes no/i' /etc/sshd_config
+sed -i -e 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/i' /etc/sshd_config
+sed -i -e 's/#PermitUserEnvironment no/PermitUserEnvironment yes/i' /etc/sshd_config
+sed -i -e 's/#UseDNS yes/UseDNS no/i' /etc/sshd_config
+
+chmod go-w /etc/sshd_config
+
+echo "==> set up user's ssh config files"
+
+ssh-user-config -y -p ''
+
+sed -i.bak -e 's/^TMP/#TMP/; s/^TEMP/#TEMP/; s/^unset TMP/#unset TMP/' /etc/profile
+
+SSHENV=$SYSTEMDRIVE/Users/$USERNAME/.ssh/environment
+
+echo "APPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Roaming" >>$SSHENV
+echo "CommonProgramFiles=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+echo "LOCALAPPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local" >>$SSHENV
+echo "ProgramData=$SYSTEMDRIVE\\ProgramData" >>$SSHENV
+echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
+echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
+echo "SESSIONNAME=Console" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+# to override "cyg_server":
+echo "USERNAME=$USERNAME" >>$SSHENV
+
+if [ -d "$SYSTEMDRIVE/Program Files (x86)" ];then
+  echo "CommonProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)\\Common Files" >>$SSHENV
+  echo "CommonProgramW6432=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+  echo "ProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)" >>$SSHENV
+  echo "ProgramW6432=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+fi

--- a/template/windows8/floppy/cygwin.sh
+++ b/template/windows8/floppy/cygwin.sh
@@ -40,8 +40,8 @@ echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
 echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
 echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
 echo "SESSIONNAME=Console" >>$SSHENV
-echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
-echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
 # to override "cyg_server":
 echo "USERNAME=$USERNAME" >>$SSHENV
 

--- a/template/windows8/floppy/openssh.bat
+++ b/template/windows8/floppy/openssh.bat
@@ -33,12 +33,33 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\passwd') | Foreach
 echo ==^> Fixing opensshd to not be strict
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'StrictModes yes', 'StrictModes no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PubkeyAuthentication yes', 'PubkeyAuthentication yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PermitUserEnvironment no', 'PermitUserEnvironment yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#UseDNS yes', 'UseDNS no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'Banner /etc/banner.txt', '#Banner /etc/banner.txt' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
 cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'APPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Roaming'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles=%SystemDrive%\Program Files\Common Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'LOCALAPPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Local'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramData=%SystemDrive%\ProgramData'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles=%SystemDrive%\Program Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PSModulePath=%SystemDrive%\Windows\system32\WindowsPowerShell\v1.0\Modules\'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PUBLIC=%SystemDrive%\Users\Public'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'SESSIONNAME=Console'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TEMP=%windir%\Temp'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TMP=%windir%\Temp'"
+:: to override "cyg_server":
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'USERNAME=%USERNAME%'"
+
+if exist "%SystemDrive%\Program Files (x86)" (
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles(x86)=%SystemDrive%\Program Files (x86)\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramW6432=%SystemDrive%\Program Files\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles(x86)=%SystemDrive%\Program Files (x86)'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramW6432=%SystemDrive%\Program Files'"
+)
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows8/win8x64-enterprise-cygwin.json
+++ b/template/windows8/win8x64-enterprise-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows8/win8x64-enterprise-cygwin.json
+++ b/template/windows8/win8x64-enterprise-cygwin.json
@@ -17,9 +17,9 @@
       "ssh_password": "vagrant",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows8/win8x64-pro-cygwin.json
+++ b/template/windows8/win8x64-pro-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,6 +46,7 @@
       "floppy_files": [
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -63,10 +65,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows8/win8x64-pro-cygwin.json
+++ b/template/windows8/win8x64-pro-cygwin.json
@@ -17,9 +17,9 @@
       "ssh_password": "vagrant",
       "floppy_files": [
         "floppy/win8x64-pro/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -44,9 +44,9 @@
       "ssh_password": "vagrant",
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
+        "floppy/cygwin.sh",
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows8/win8x86-enterprise-cygwin.json
+++ b/template/windows8/win8x86-enterprise-cygwin.json
@@ -17,9 +17,9 @@
       "ssh_password": "vagrant",
       "floppy_files": [
         "floppy/win8x86-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win8x86-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows8/win8x86-enterprise-cygwin.json
+++ b/template/windows8/win8x86-enterprise-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows8/win8x86-pro-cygwin.json
+++ b/template/windows8/win8x86-pro-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,6 +47,7 @@
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -64,10 +66,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows8/win8x86-pro-cygwin.json
+++ b/template/windows8/win8x86-pro-cygwin.json
@@ -17,9 +17,9 @@
       "ssh_password": "vagrant",
       "floppy_files": [
         "floppy/win8x86-pro/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -45,9 +45,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win8x86-pro/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows81/floppy/cygwin.bat
+++ b/template/windows81/floppy/cygwin.bat
@@ -38,15 +38,9 @@ echo ==^> Opening firewall port 22 for the sshd service
 netsh advfirewall firewall add rule name="SSHD" dir=in action=allow program="%CYGWIN_HOME%\usr\sbin\sshd.exe" enable=yes
 netsh advfirewall firewall add rule name="ssh" dir=in action=allow protocol=TCP localport=22
 
-echo ==^> Make user home directories default to their windows profile directory
-bash -c "ln -s ""$(dirname $(cygpath -D))"" /home/$USERNAME"
-bash -c "mkpasswd -l -p ""$(cygpath -H)"" >/etc/passwd"
+set CYGWIN=ntsecbinmode mintty nodosfilewarning
 
-echo ==^> Creating /etc/group (required by sshd)
-bash -c "mkgroup -l >/etc/group"
-
-echo ==^> set up sshd config files
-bash -c "ssh-host-config -y -c ""ntsecbinmode mintty nodosfilewarning"" -w ""abc&&123!!"" "
+bash a:/cygwin.sh "abc&&123!!"
 
 echo ==^> Deleting the Cygwin installer and downloaded packages
 del "%CYGWIN_SETUP_LOCAL_PATH%"

--- a/template/windows81/floppy/cygwin.sh
+++ b/template/windows81/floppy/cygwin.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+export CYGWIN="ntsecbinmode mintty nodosfilewarning"
+
+echo '==> Make user home directories default to their windows profile directory'
+
+ln -s "$(dirname $(cygpath -D))" /home/$USERNAME
+
+mkpasswd -l -p "$(cygpath -H)" >/etc/passwd
+
+echo '==> Creating /etc/group (required by sshd)'
+mkgroup -l >/etc/group
+
+echo "==> set up host's ssh config files"
+
+ssh-host-config -y -c "$CYGWIN" -w $1
+
+chmod a+w /etc/sshd_config
+
+sed -i -e 's/StrictModes yes/StrictModes no/i' /etc/sshd_config
+sed -i -e 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/i' /etc/sshd_config
+sed -i -e 's/#PermitUserEnvironment no/PermitUserEnvironment yes/i' /etc/sshd_config
+sed -i -e 's/#UseDNS yes/UseDNS no/i' /etc/sshd_config
+
+chmod go-w /etc/sshd_config
+
+echo "==> set up user's ssh config files"
+
+ssh-user-config -y -p ''
+
+sed -i.bak -e 's/^TMP/#TMP/; s/^TEMP/#TEMP/; s/^unset TMP/#unset TMP/' /etc/profile
+
+SSHENV=$SYSTEMDRIVE/Users/$USERNAME/.ssh/environment
+
+echo "APPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Roaming" >>$SSHENV
+echo "CommonProgramFiles=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+echo "LOCALAPPDATA=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local" >>$SSHENV
+echo "ProgramData=$SYSTEMDRIVE\\ProgramData" >>$SSHENV
+echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
+echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
+echo "SESSIONNAME=Console" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+# to override "cyg_server":
+echo "USERNAME=$USERNAME" >>$SSHENV
+
+if [ -d "$SYSTEMDRIVE/Program Files (x86)" ];then
+  echo "CommonProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)\\Common Files" >>$SSHENV
+  echo "CommonProgramW6432=$SYSTEMDRIVE\\Program Files\\Common Files" >>$SSHENV
+  echo "ProgramFiles(x86)=$SYSTEMDRIVE\\Program Files (x86)" >>$SSHENV
+  echo "ProgramW6432=$SYSTEMDRIVE\\Program Files" >>$SSHENV
+fi

--- a/template/windows81/floppy/cygwin.sh
+++ b/template/windows81/floppy/cygwin.sh
@@ -40,8 +40,8 @@ echo "ProgramFiles=$SYSTEMDRIVE\\Program Files" >>$SSHENV
 echo "PSModulePath=$SYSTEMDRIVE\\Windows\\system32\\WindowsPowerShell\\v1.0\\Modules\\" >>$SSHENV
 echo "PUBLIC=$SYSTEMDRIVE\\Users\\Public" >>$SSHENV
 echo "SESSIONNAME=Console" >>$SSHENV
-echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
-echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Temp" >>$SSHENV
+echo "TEMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
+echo "TMP=$SYSTEMDRIVE\\Users\\$USERNAME\\AppData\\Local\\Temp" >>$SSHENV
 # to override "cyg_server":
 echo "USERNAME=$USERNAME" >>$SSHENV
 

--- a/template/windows81/floppy/openssh.bat
+++ b/template/windows81/floppy/openssh.bat
@@ -33,12 +33,33 @@ powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\passwd') | Foreach
 echo ==^> Fixing opensshd to not be strict
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'StrictModes yes', 'StrictModes no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PubkeyAuthentication yes', 'PubkeyAuthentication yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#PermitUserEnvironment no', 'PermitUserEnvironment yes' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace '#UseDNS yes', 'UseDNS no' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
+powershell -Command "(Get-Content '%ProgramFiles%\OpenSSH\etc\sshd_config') | Foreach-Object { $_ -replace 'Banner /etc/banner.txt', '#Banner /etc/banner.txt' } | Set-Content '%ProgramFiles%\OpenSSH\etc\sshd_config'"
 
 echo ==^> Setting temp location
 rd /S /Q "%ProgramFiles%\OpenSSH\tmp"
 cmd /c ""%ProgramFiles%\OpenSSH\bin\junction.exe" /accepteula "%ProgramFiles%\OpenSSH\tmp" C:\Windows\Temp"
 cmd /c %windir%\System32\icacls.exe "%TEMP%" /grant %USERNAME%:(OI)(CI)F
-powershell -Command "Add-Content %USERPROFILE%\.ssh\environment "TEMP=C:\Windows\Temp""
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'APPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Roaming'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles=%SystemDrive%\Program Files\Common Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'LOCALAPPDATA=%SystemDrive%\Users\%USERNAME%\AppData\Local'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramData=%SystemDrive%\ProgramData'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles=%SystemDrive%\Program Files'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PSModulePath=%SystemDrive%\Windows\system32\WindowsPowerShell\v1.0\Modules\'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'PUBLIC=%SystemDrive%\Users\Public'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'SESSIONNAME=Console'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TEMP=%windir%\Temp'"
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'TMP=%windir%\Temp'"
+:: to override "cyg_server":
+powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'USERNAME=%USERNAME%'"
+
+if exist "%SystemDrive%\Program Files (x86)" (
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramFiles(x86)=%SystemDrive%\Program Files (x86)\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'CommonProgramW6432=%SystemDrive%\Program Files\Common Files'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramFiles(x86)=%SystemDrive%\Program Files (x86)'"
+   powershell -Command "Add-Content %USERPROFILE%\.ssh\environment 'ProgramW6432=%SystemDrive%\Program Files'"
+)
 
 echo ==^> Record the path for use by provisioners
 <nul set /p ".=%PATH%" > %TEMP%\PATH

--- a/template/windows81/win81x64-enterprise-cygwin.json
+++ b/template/windows81/win81x64-enterprise-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -47,6 +48,7 @@
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -66,10 +68,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows81/win81x64-enterprise-cygwin.json
+++ b/template/windows81/win81x64-enterprise-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,9 +46,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows81/win81x64-pro-cygwin.json
+++ b/template/windows81/win81x64-pro-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -47,6 +48,7 @@
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -66,10 +68,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows81/win81x64-pro-cygwin.json
+++ b/template/windows81/win81x64-pro-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x64-pro/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,9 +46,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x64-pro/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows81/win81x86-enterprise-cygwin.json
+++ b/template/windows81/win81x86-enterprise-cygwin.json
@@ -18,9 +18,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x86-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,9 +46,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x86-enterprise/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"

--- a/template/windows81/win81x86-enterprise-cygwin.json
+++ b/template/windows81/win81x86-enterprise-cygwin.json
@@ -20,6 +20,7 @@
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -47,6 +48,7 @@
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -65,10 +67,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows81/win81x86-pro-cygwin.json
+++ b/template/windows81/win81x86-pro-cygwin.json
@@ -19,6 +19,7 @@
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -47,6 +48,7 @@
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"
@@ -65,10 +67,7 @@
       "remote_path": "/tmp/script.bat",
       "environment_vars": [
         "PROVISIONER={{user `provisioner`}}",
-        "PROVISIONER_VERSION={{user `provisioner_version`}}",
-        "TEMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "TMP=$USERPROFILE\\\\AppData\\\\Local\\\\Temp",
-        "USERNAME=$USER"
+        "PROVISIONER_VERSION={{user `provisioner_version`}}"
       ],
       "execute_command": "{{.Vars}} cmd /c $(/bin/cygpath -m '{{.Path}}')",
       "scripts": [

--- a/template/windows81/win81x86-pro-cygwin.json
+++ b/template/windows81/win81x86-pro-cygwin.json
@@ -17,9 +17,9 @@
       "ssh_password": "vagrant",
       "floppy_files": [
         "floppy/win81x86-pro/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat"
       ],
@@ -46,9 +46,9 @@
       "ssh_wait_timeout": "10000s",
       "floppy_files": [
         "floppy/win81x86-pro/Autounattend.xml",
+        "floppy/cygwin.sh",
         "floppy/00-run-all-scripts.cmd",
         "floppy/powerconfig.bat",
-        "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
         "floppy/oracle-cert.cer"


### PR DESCRIPTION
Moved all bash commands from cygwin.bat to cygwin.sh
Use "ssh-user-config" to create .ssh directory in Cygwin (floppy/cygwin.bat)
Changed 'StrictModes yes' to 'StrictModes no' in etc/sshd_config (cygwin.bat and openssh.bat)
Changed '#PubkeyAuthentication yes' to 'PubkeyAuthentication yes' in etc/sshd_config (cygwin.bat and openssh.bat)
Changed '#PermitUserEnvironment no' to 'PermitUserEnvironment yes' in etc/sshd_config (cygwin.bat and openssh.bat)
Changed '#UseDNS yes' to 'UseDNS no' in etc/sshd_config (cygwin.bat and openssh.bat)
Changed 'Banner /etc/banner.txt' to '#Banner /etc/banner.txt' in etc/sshd_config (openssh.bat only)
Repopulate the following variables that Cygwin removes from the environment:

```
APPDATA
CommonProgramFiles
LOCALAPPDATA
ProgramData
ProgramFiles
PSModulePath
PUBLIC
SESSIONNAME
TEMP
TMP
USERNAME (set to vagrant, not cyg_server)
CommonProgramFiles(x86) (64 bit only)
CommonProgramW6432 (64 bit only)
ProgramFiles(x86) (64 bit only)
ProgramW6432 (64 bit only)
```

We are not yet populating these missing values:

```
FP_NO_HOST_CHECK
NUMBER_OF_PROCESSORS
PROCESSOR_ARCHITECTURE
PROCESSOR_ARCHITEW6432
PROCESSOR_IDENTIFIER
PROCESSOR_LEVEL
PROCESSOR_REVISION
windows_tracing_flags
windows_tracing_logfile
```
