### PR TITLE
Add option to install Puppet as a provisioner on CentOS boxes

### DIFF
--- a/template/centos/script/provisioner.sh
+++ b/template/centos/script/provisioner.sh
@@ -43,7 +43,7 @@ case "${PROVISIONER}" in
     ;;
 
   'puppet')
-    OS_MAJRELEASE=$(cat /etc/redhat-release | perl -n -e'/release ([\d]*)/ && print $1')
+    OS_MAJRELEASE=$(egrep -Eo 'release ([0-9][0-9.]*)' /etc/redhat-release | cut -f2 -d' ' | cut -f1 -d.)
 
     echo "Installing Puppet Labs repositories"
     rpm -ipv "http://yum.puppetlabs.com/puppetlabs-release-el-${OS_MAJRELEASE}.noarch.rpm"

--- a/template/centos/script/provisioner.sh
+++ b/template/centos/script/provisioner.sh
@@ -1,19 +1,22 @@
-#!/usr/bin/env bash
+#!/bin/bash -eux
 
-# Break on error
-set -e
-# Exit if we use any unset variable (use ${VAR:-} to test for unset var)
-set -o nounset
+# Bash options enabled:
+#   - Break on error
+#   - Exit if we use any unset variable (use ${VAR:-} to test for unset var)
+#   - Be verbose
 
-# Set $PROVISIONER & $PROVISIONER_VERSION inside of Packer's template:
-#
+# Set ${PROVISIONER} & ${PROVISIONER_VERSION} inside of Packer's template.
+# if ${PROVISIONER_VERSION} isn't defined, set it to 'latest'
+PROVISIONER_VERSION=${PROVISIONER_VERSION:-latest}
+
 # Valid values for $PROVISIONER are:
 #   'provisionerless' -- build a box without a provisioner
 #   'chef'            -- build a box with the Chef provisioner
 #   'salt'            -- build a box with the Salt provisioner
+#   'puppet'          -- build a box with the Puppet provisioner
 #
 # When $PROVISIONER != 'provisionerless' valid options for
-# $PROVISIONER_VERSION are:
+# ${PROVISIONER_VERSION} are:
 #   'x.y.z'           -- build a box with version x.y.z of the Chef provisioner
 #   'x.y'             -- build a box with version x.y of the Salt provisioner
 #   'latest'          -- build a box with the latest version of the provisioner
@@ -25,7 +28,7 @@ case "${PROVISIONER}" in
       curl -L https://www.opscode.com/chef/install.sh | sh
     else
       echo "Installing Chef version ${PROVISIONER_VERSION}"
-      curl -L https://www.opscode.com/chef/install.sh | sh -s -- -v $PROVISIONER_VERSION
+      curl -L https://www.opscode.com/chef/install.sh | sh -s -- -v ${PROVISIONER_VERSION}
     fi
     ;;
 
@@ -34,8 +37,23 @@ case "${PROVISIONER}" in
       echo "Installing latest Salt version"
       wget -O - http://bootstrap.saltstack.org | sudo sh
     else
-      echo "Installing Salt version $PROVISIONER_VERSION"
-      curl -L http://bootstrap.saltstack.org | sudo sh -s -- git $PROVISIONER_VERSION
+      echo "Installing Salt version ${PROVISIONER_VERSION}"
+      curl -L http://bootstrap.saltstack.org | sudo sh -s -- git ${PROVISIONER_VERSION}
+    fi
+    ;;
+
+  'puppet')
+    OS_MAJRELEASE=$(cat /etc/redhat-release | perl -n -e'/release ([\d]*)/ && print $1')
+
+    echo "Installing Puppet Labs repositories"
+    rpm -ipv "http://yum.puppetlabs.com/puppetlabs-release-el-${OS_MAJRELEASE}.noarch.rpm"
+
+    if [[ ${PROVISIONER_VERSION:-} == 'latest' ]]; then
+      echo "Installing latest Puppet version"
+      yum -y install puppet
+    else
+      echo "Installing Puppet version ${PROVISIONER_VERSION}"
+      yum -y install "puppet-${PROVISIONER_VERSION}"
     fi
     ;;
 


### PR DESCRIPTION
I've added Puppet as an option, using the Puppet Labs yum repositories. To do so, I've added a couple of configuration variables to the packer templates for each CentOS release and updated the provisioner script.

I'm starting the work to add it to other *nix variants with repositories (Fedora, Debian, Ubuntu) next but since I needed CentOS right now I thought I'd open a pull request and get the ball rolling.
