### PR TITLE
Remove trailing whitespace from the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ basebox
 =======
 
 Packer definitions for vagrant VirtualBox and VMware baseboxes.
-These are the vagrant baseboxes I use for my own personal projents.
+These are the vagrant baseboxes I use for my own personal projects.
 This project is run against a private Jenkins instance, and as template
 definitions are added and/or updated, links to the generated images are
 added below:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 basebox
 =======
 
-Packer definitions for vagrant VirtualBox and VMware baseboxes. 
-These are the vagrant baseboxes I use for my own personal projents. 
+Packer definitions for vagrant VirtualBox and VMware baseboxes.
+These are the vagrant baseboxes I use for my own personal projents.
 This project is run against a private Jenkins instance, and as template
 definitions are added and/or updated, links to the generated images are
 added below:


### PR DESCRIPTION
Sorry if this may seem trivial or irrelevant. The other lines didn't have trailing whitespace, so I figured I'd submit this change. Thank you.
