### PR TITLE
fixing salt provisioner

### DIFF
--- a/template/ubuntu/script/provisioner.sh
+++ b/template/ubuntu/script/provisioner.sh
@@ -68,7 +68,7 @@ case "${PROVISIONER}" in
     ;;
 
   'salt')
-    install_puppet
+    install_salt
     ;;
 
   *)


### PR DESCRIPTION
Salt was calling a nonexistent install_puppet function.  Corrected to call install_salt function.

Signed-off-by: W. S. Wellington bwellington@fulcrum.net
